### PR TITLE
Heterogeneous notion of signature with strength

### DIFF
--- a/UniMath/CategoryTheory/EndofunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/EndofunctorsMonoidal.v
@@ -33,25 +33,27 @@ Require Import UniMath.CategoryTheory.UnicodeNotations.
 *)
 Section Monoidal_Structure_on_Endofunctors.
 
-Context {C : precategory}.
+(** while this is normally used for endofunctors, it can be done more generally *)
 
-Definition ρ_functor (X : functor C C) :
-  nat_trans (functor_composite X (functor_identity C)) X := nat_trans_functor_id_right X.
+Context {C D : precategory}.
 
-Definition ρ_functor_inv (X : functor C C) :
-  nat_trans X (functor_composite X (functor_identity C)) := ρ_functor X.
+Definition ρ_functor (X : functor C D) :
+  nat_trans (functor_composite X (functor_identity D)) X := nat_trans_functor_id_right X.
 
-Definition λ_functor (X : functor C C) :
+Definition ρ_functor_inv (X : functor C D) :
+  nat_trans X (functor_composite X (functor_identity D)) := ρ_functor X.
+
+Definition λ_functor (X : functor C D) :
   nat_trans (functor_composite (functor_identity C) X) X := ρ_functor X.
 
-Definition λ_functor_inv (X : functor C C) :
+Definition λ_functor_inv (X : functor C D) :
   nat_trans X (functor_composite (functor_identity C) X) := ρ_functor X.
 
-Definition α_functor (X Y Z : functor C C) :
+Definition α_functor (X Y : functor C C)(Z : functor C D) :
   nat_trans (functor_composite (functor_composite X Y) Z)
             (functor_composite X (functor_composite Y Z)) := nat_trans_functor_assoc X Y Z.
 
-Definition α_functor_inv (X Y Z : functor C C) :
+Definition α_functor_inv (X Y : functor C C)(Z : functor C D) :
   nat_trans (functor_composite X (functor_composite Y Z))
             (functor_composite (functor_composite X Y) Z) := α_functor X Y Z.
 

--- a/UniMath/CategoryTheory/EndofunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/EndofunctorsMonoidal.v
@@ -7,6 +7,7 @@ SubstitutionSystems
 2015
 
 Modified by: Anders Mörtberg, 2016
+             Ralph Matthes, 2017
 
 ************************************************************)
 
@@ -16,6 +17,7 @@ Modified by: Anders Mörtberg, 2016
 Contents :
 
 - Definition of the (weak) monoidal structure on endofunctors
+  (however, the definitions are not confined to endofunctors)
 
 
 ************************************************************)
@@ -49,11 +51,14 @@ Definition λ_functor (X : functor C D) :
 Definition λ_functor_inv (X : functor C D) :
   nat_trans X (functor_composite (functor_identity C) X) := ρ_functor X.
 
-Definition α_functor (X Y : functor C C)(Z : functor C D) :
+
+Context {E F: precategory}.
+
+Definition α_functor (X : functor C D)(Y : functor D E)(Z : functor E F) :
   nat_trans (functor_composite (functor_composite X Y) Z)
             (functor_composite X (functor_composite Y Z)) := nat_trans_functor_assoc X Y Z.
 
-Definition α_functor_inv (X Y : functor C C)(Z : functor C D) :
+Definition α_functor_inv (X : functor C D)(Y : functor D E)(Z : functor E F) :
   nat_trans (functor_composite X (functor_composite Y Z))
             (functor_composite (functor_composite X Y) Z) := α_functor X Y Z.
 

--- a/UniMath/CategoryTheory/category_hset_structures.v
+++ b/UniMath/CategoryTheory/category_hset_structures.v
@@ -732,6 +732,12 @@ Proof.
 now apply BinProducts_slice_precat, PullbacksHSET.
 Defined.
 
+Lemma BinCoproducts_HSET_slice X : BinCoproducts (HSET / X).
+Proof.
+now apply BinCoproducts_slice_precat, BinCoproductsHSET.
+Defined.
+
+
 (** Direct proof that HSET/X has exponentials using explicit formula in example 2.2 of:
 
     https://ncatlab.org/nlab/show/locally+cartesian+closed+category#in_category_theory

--- a/UniMath/CategoryTheory/limits/bincoproducts.v
+++ b/UniMath/CategoryTheory/limits/bincoproducts.v
@@ -941,15 +941,30 @@ Defined.
 
 End def_functor_pointwise_coprod.
 
+
+Section generalized_option_functors.
+
+Context {C : precategory} (CC : BinCoproducts C).
+
+(* The functors "a + _" and "_ + a" *)
+Definition constcoprod_functor1 (a : C) : functor C C :=
+  BinCoproduct_of_functors C C CC (constant_functor C C a) (functor_identity C).
+
+Definition constcoprod_functor2 (a : C) : functor C C :=
+  BinCoproduct_of_functors C C CC (functor_identity C) (constant_functor C C a).
+
+
 Section option_functor.
 
-Context {C : precategory} (CC : BinCoproducts C) (TC : Terminal C).
+Context (TC : Terminal C).
 Let one : C := TerminalObject TC.
 
 Definition option_functor : functor C C :=
-  BinCoproduct_of_functors C C CC (constant_functor _ _ one) (functor_identity C).
+  constcoprod_functor1 one.
 
 End option_functor.
+
+End generalized_option_functors.
 
 (** ** Construction of isBinCoproduct from an isomorphism to BinCoproduct. *)
 Section BinCoproduct_from_iso.

--- a/UniMath/SubstitutionSystems/BinProductOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinProductOfSignatures.v
@@ -30,24 +30,26 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
 
-Arguments θ_source {_ _} _ .
-Arguments θ_target {_ _} _ .
-Arguments θ_Strength1 {_ _ _} _ .
-Arguments θ_Strength2 {_ _ _} _ .
-Arguments θ_Strength1_int {_ _ _} _ .
-Arguments θ_Strength2_int {_ _ _} _ .
+Arguments θ_source {_ _ _ _} _ .
+Arguments θ_target {_ _ _ _} _ .
+Arguments θ_Strength1 {_ _ _ _ _} _ .
+Arguments θ_Strength2 {_ _ _ _ _} _ .
+Arguments θ_Strength1_int {_ _ _ _ _} _ .
+Arguments θ_Strength2_int {_ _ _ _ _} _ .
 
 Section binproduct_of_signatures.
 
 Variable C : precategory.
 Variable hsC : has_homsets C.
-Variable PC : BinProducts C.
+Variable D : precategory.
+Variable hs : has_homsets D.
+Variable PD : BinProducts D.
 
 Section construction.
 
-Local Notation "'CCC'" := (BinProducts_functor_precat C C PC hsC : BinProducts [C, C, hsC]).
+Local Notation "'PCD'" := (BinProducts_functor_precat C D PD hs : BinProducts [C, D, hs]).
 
-Variables H1 H2 : functor [C, C, hsC] [C, C, hsC].
+Variables H1 H2 : functor [C, C, hsC] [C, D, hs].
 
 Variable θ1 : θ_source H1 ⟶ θ_target H1.
 Variable θ2 : θ_source H2 ⟶ θ_target H2.
@@ -59,14 +61,14 @@ Variable S22 : θ_Strength2 θ2.
 
 (** * Definition of the data of the product of two signatures *)
 
-Definition H : functor [C, C, hsC] [C, C, hsC] :=
-  BinProduct_of_functors _ _ CCC H1 H2.
+Definition H : functor [C, C, hsC] [C, D, hs] :=
+  BinProduct_of_functors _ _ PCD H1 H2.
 
 Local Definition θ_ob_fun (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
    ∏ c : C,
     (functor_composite_data (pr1 Z)
-     (BinProduct_of_functors_data C C PC (H1 X) (H2 X))) c
-   --> (BinProduct_of_functors_data C C PC (H1 (functor_composite (pr1 Z) X))
+     (BinProduct_of_functors_data C D PD (H1 X) (H2 X))) c
+   --> (BinProduct_of_functors_data C D PD (H1 (functor_composite (pr1 Z) X))
        (H2 (functor_composite (pr1 Z) X))) c.
 Proof.
   intro c.
@@ -94,11 +96,11 @@ Proof.
 Defined.
 
 Local Lemma is_nat_trans_θ_ob :
- is_nat_trans (θ_source_functor_data C hsC H) (θ_target_functor_data C hsC H)
+ is_nat_trans (θ_source_functor_data C hsC D hs H) (θ_target_functor_data C hsC D hs H)
      θ_ob.
 Proof.
   intros [X Z] [X' Z'] [α β].
-  apply (nat_trans_eq hsC); intro c; simpl.
+  apply (nat_trans_eq hs); intro c; simpl.
   eapply pathscomp0; [ | eapply pathsinv0, BinProductOfArrows_comp].
   eapply pathscomp0; [ apply cancel_postcomposition, BinProductOfArrows_comp |].
   eapply pathscomp0; [ apply BinProductOfArrows_comp |].
@@ -118,7 +120,7 @@ Defined.
 Lemma ProductStrength1 : θ_Strength1 θ.
 Proof.
   intro X.
-  apply (nat_trans_eq hsC); intro x.
+  apply (nat_trans_eq hs); intro x.
   eapply pathscomp0; [apply BinProductOfArrows_comp|].
   apply pathsinv0, BinProduct_endo_is_identity.
   + rewrite BinProductOfArrowsPr1.
@@ -132,7 +134,7 @@ Qed.
 Lemma ProductStrength2 : θ_Strength2 θ.
 Proof.
   intros X Z Z' Y α.
-  apply (nat_trans_eq hsC); intro x.
+  apply (nat_trans_eq hs); intro x.
   eapply pathscomp0; [ apply BinProductOfArrows_comp |].
   apply pathsinv0.
   eapply pathscomp0; [ apply cancel_postcomposition; simpl; apply BinProductOfArrows_comp|].
@@ -152,7 +154,7 @@ Variable S22' : θ_Strength2_int θ2.
 Lemma ProductStrength1' : θ_Strength1_int θ.
 Proof.
   clear S11 S12 S21 S22 S12' S22'; intro X.
-  apply (nat_trans_eq hsC); intro x.
+  apply (nat_trans_eq hs); intro x.
   eapply pathscomp0; [ apply BinProductOfArrows_comp |].
   apply pathsinv0, BinProduct_endo_is_identity.
   + rewrite BinProductOfArrowsPr1.
@@ -166,7 +168,7 @@ Qed.
 Lemma ProductStrength2' : θ_Strength2_int θ.
 Proof.
   clear S11 S12 S21 S22 S11' S21'; intros X Z Z'.
-  apply (nat_trans_eq hsC); intro x; simpl.
+  apply (nat_trans_eq hs); intro x; simpl.
   rewrite id_left.
   eapply pathscomp0; [apply BinProductOfArrows_comp|].
   apply pathsinv0.
@@ -183,7 +185,7 @@ Qed.
 End construction.
 
 (** Binary product of signatures *)
-Definition BinProduct_of_Signatures (S1 S2 : Signature C hsC) : Signature C hsC.
+Definition BinProduct_of_Signatures (S1 S2 : Signature C hsC D hs) : Signature C hsC D hs.
 Proof.
   (* destruct S1 as [H1 [θ1 [S11' S12']]]. *)
   (* destruct S2 as [H2 [θ2 [S21' S22']]]. *)
@@ -194,9 +196,9 @@ Proof.
   + apply ProductStrength2'; [apply (pr2 (pr2 (pr2 S1)))|apply (pr2 (pr2 (pr2 S2)))].
 Defined.
 
-Lemma is_omega_cocont_BinProduct_of_Signatures (S1 S2 : Signature C hsC)
-  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2)
-  (hE : ∏ x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C PC hsC) x)) :
+Lemma is_omega_cocont_BinProduct_of_Signatures (S1 S2 : Signature C hsC D hs)
+  (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) (PC: BinProducts C)
+  (hE : ∏ x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C D PD hs) x)) :
   is_omega_cocont (BinProduct_of_Signatures S1 S2).
 Proof.
 destruct S1 as [F1 [F2 [F3 F4]]]; simpl in *.

--- a/UniMath/SubstitutionSystems/BinSumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/BinSumOfSignatures.v
@@ -37,24 +37,26 @@ Local Notation "# F" := (functor_on_morphisms F) (at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
 
-Arguments θ_source {_ _} _ .
-Arguments θ_target {_ _} _ .
-Arguments θ_Strength1 {_ _ _} _ .
-Arguments θ_Strength2 {_ _ _} _ .
-Arguments θ_Strength1_int {_ _ _} _ .
-Arguments θ_Strength2_int {_ _ _} _ .
+Arguments θ_source {_ _ _ _} _ .
+Arguments θ_target {_ _ _ _} _ .
+Arguments θ_Strength1 {_ _ _ _ _} _ .
+Arguments θ_Strength2 {_ _ _ _ _} _ .
+Arguments θ_Strength1_int {_ _ _ _ _} _ .
+Arguments θ_Strength2_int {_ _ _ _ _} _ .
 
 Section binsum_of_signatures.
 
 Variable C : precategory.
-Variable hs : has_homsets C.
-Variable CC : BinCoproducts C.
+Variable hsC : has_homsets C.
+Variable D : precategory.
+Variable hs : has_homsets D.
+Variable CD : BinCoproducts D.
 
 Section construction.
 
-Local Notation "'CCC'" := (BinCoproducts_functor_precat C C CC hs : BinCoproducts [C, C, hs]).
+Local Notation "'CCD'" := (BinCoproducts_functor_precat C D CD hs : BinCoproducts [C, D, hs]).
 
-Variables H1 H2 : functor [C, C, hs] [C, C, hs].
+Variables H1 H2 : functor [C, C, hsC] [C, D, hs].
 
 Variable θ1 : θ_source H1 ⟶ θ_target H1.
 Variable θ2 : θ_source H2 ⟶ θ_target H2.
@@ -66,16 +68,16 @@ Variable S22 : θ_Strength2 θ2.
 
 (** * Definition of the data of the sum of two signatures *)
 
-Definition H : functor [C, C, hs] [C, C, hs] := BinCoproduct_of_functors _ _ CCC H1 H2.
+Definition H : functor [C, C, hsC] [C, D, hs] := BinCoproduct_of_functors _ _ CCD H1 H2.
 
 (* This becomes too slow: *)
 (* Definition H : functor [C, C, hs] [C, C, hs] := BinCoproduct_of_functors_alt CCC H1 H2. *)
 
-Local Definition θ_ob_fun (X : [C, C, hs]) (Z : precategory_Ptd C hs) :
+Local Definition θ_ob_fun (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
    ∏ c : C,
     (functor_composite_data (pr1 Z)
-     (BinCoproduct_of_functors_data C C CC (H1 X) (H2 X))) c
-   --> (BinCoproduct_of_functors_data C C CC (H1 (functor_composite (pr1 Z) X))
+     (BinCoproduct_of_functors_data C D CD (H1 X) (H2 X))) c
+   --> (BinCoproduct_of_functors_data C D CD (H1 (functor_composite (pr1 Z) X))
        (H2 (functor_composite (pr1 Z) X))) c.
 Proof.
   intro c.
@@ -84,7 +86,7 @@ Proof.
   - exact (pr1 (θ2 (X ⊗ Z)) c).
 Defined.
 
-Local Lemma is_nat_trans_θ_ob_fun (X : [C, C, hs]) (Z : precategory_Ptd C hs):
+Local Lemma is_nat_trans_θ_ob_fun (X : [C, C, hsC]) (Z : precategory_Ptd C hsC):
    is_nat_trans _ _ (θ_ob_fun X Z).
 Proof.
   intros x x' f.
@@ -103,7 +105,7 @@ Proof.
 Defined.
 
 Local Lemma is_nat_trans_θ_ob :
-  is_nat_trans (θ_source_functor_data C hs H) (θ_target_functor_data C hs H) θ_ob.
+  is_nat_trans (θ_source_functor_data C hsC D hs H) (θ_target_functor_data C hsC D hs H) θ_ob.
 Proof.
   intros XZ X'Z' αβ.
   assert (Hyp1:= nat_trans_ax θ1 _ _ αβ).
@@ -223,7 +225,7 @@ Qed.
 
 End construction.
 
-Definition BinSum_of_Signatures (S1 S2 : Signature C hs) : Signature C hs.
+Definition BinSum_of_Signatures (S1 S2 : Signature C hsC D hs) : Signature C hsC D hs.
 Proof.
   destruct S1 as [H1 [θ1 [S11' S12']]].
   destruct S2 as [H2 [θ2 [S21' S22']]].
@@ -234,7 +236,7 @@ Proof.
   + apply SumStrength2'; assumption.
 Defined.
 
-Lemma is_omega_cocont_BinSum_of_Signatures (S1 S2 : Signature C hs)
+Lemma is_omega_cocont_BinSum_of_Signatures (S1 S2 : Signature C hsC D hs)
   (h1 : is_omega_cocont S1) (h2 : is_omega_cocont S2) (PC : BinProducts C) :
   is_omega_cocont (BinSum_of_Signatures S1 S2).
 Proof.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -112,7 +112,7 @@ destruct n; simpl.
 Defined.
 
 Definition precomp_option_iter_Signature (BCC : BinCoproducts C)
-  (TC : Terminal C) (n : nat) : Signature C hsC.
+  (TC : Terminal C) (n : nat) : Signature C hsC C hsC.
 Proof.
 mkpair.
 - apply (precomp_option_iter BCC TC n).
@@ -128,8 +128,8 @@ Defined.
 Context (BPC : BinProducts C) (BCC : BinCoproducts C).
 
 (** [nat] to a Signature *)
-Definition Arity_to_Signature (TC : Terminal C) (xs : list nat) : Signature C hsC :=
-     foldr1 (BinProduct_of_Signatures _ _ BPC) (IdSignature _ _)
+Definition Arity_to_Signature (TC : Terminal C) (xs : list nat) : Signature C hsC C hsC :=
+     foldr1 (BinProduct_of_Signatures _ _ _ _ BPC) (IdSignature _ _)
         (map (precomp_option_iter_Signature BCC TC) xs).
 
 Let BPC2 BPC := BinProducts_functor_precat C _ BPC hsC.
@@ -151,13 +151,14 @@ destruct xs as [[|n] xs].
     apply is_omega_cocont_BinProduct_of_Signatures.
     * apply is_omega_cocont_precomp_option_iter, CLC.
     * apply (IHn (k,,xs)).
+    * assumption.
     * intro x; apply (H x).
 Defined.
 
 (** ** Binding signature to a signature with strength *)
 Definition BindingSigToSignature (TC : Terminal C)
   (sig : BindingSig) (CC : Coproducts (BindingSigIndex sig) C) :
-  Signature C hsC.
+  Signature C hsC C hsC.
 Proof.
 apply (Sum_of_Signatures (BindingSigIndex sig)).
 - apply CC.
@@ -182,7 +183,7 @@ Let FunctorAlg F := FunctorAlg F has_homsets_C2.
 (** ** Construction of initial algebra for a signature with strength *)
 Definition SignatureInitialAlgebra
   (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (H : Signature C hsC) (Hs : is_omega_cocont H) :
+  (H : Signature C hsC C hsC) (Hs : is_omega_cocont H) :
   Initial (FunctorAlg (Id_H H)).
 Proof.
 use colimAlgInitial.
@@ -196,7 +197,7 @@ Let HSS := @hss_precategory C hsC BCC.
 (* Redefine this here so that it uses the arguments above *)
 Let InitialHSS
   (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (H : Signature C hsC) (Hs : is_omega_cocont H) :
+  (H : Signature C hsC C hsC) (Hs : is_omega_cocont H) :
   Initial (HSS H).
 Proof.
 apply InitialHSS; assumption.
@@ -205,7 +206,7 @@ Defined.
 (** ** Signature with strength and initial algebra to a HSS *)
 Definition SignatureToHSS
   (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (H : Signature C hsC) (Hs : is_omega_cocont H) :
+  (H : Signature C hsC C hsC) (Hs : is_omega_cocont H) :
   HSS H.
 Proof.
 now apply InitialHSS; assumption.
@@ -214,14 +215,14 @@ Defined.
 (** The above HSS is initial *)
 Definition SignatureToHSSisInitial
   (IC : Initial C) (CLC : Colims_of_shape nat_graph C)
-  (H : Signature C hsC) (Hs : is_omega_cocont H) :
+  (H : Signature C hsC C hsC) (Hs : is_omega_cocont H) :
   isInitial _ (SignatureToHSS IC CLC H Hs).
 Proof.
 now unfold SignatureToHSS; destruct InitialHSS.
 Qed.
 
 (* Redefine this here so that it uses the arguments above *)
-Let Monad_from_hss (H : Signature C hsC) : HSS H → Monad C.
+Let Monad_from_hss (H : Signature C hsC C hsC) : HSS H → Monad C.
 Proof.
 exact (Monad_from_hss _ _ BCC H).
 Defined.
@@ -252,7 +253,7 @@ apply functor_category_has_homsets.
 Defined.
 
 (** ** Binding signature to signature with strength for HSET *)
-Definition BindingSigToSignatureHSET (sig : BindingSig) : Signature HSET has_homsets_HSET.
+Definition BindingSigToSignatureHSET (sig : BindingSig) : Signature HSET has_homsets_HSET HSET has_homsets_HSET.
 Proof.
 use BindingSigToSignature.
 - apply BinProductsHSET.
@@ -275,7 +276,7 @@ apply (is_omega_cocont_Sum_of_Signatures _ (BindingSigIsdeceq sig)).
 Defined.
 
 (** ** Construction of initial algebra for a signature with strength for HSET *)
-Definition SignatureInitialAlgebraHSET (s : Signature HSET has_homsets_HSET) (Hs : is_omega_cocont s) :
+Definition SignatureInitialAlgebraHSET (s : Signature HSET has_homsets_HSET _ _) (Hs : is_omega_cocont s) :
   Initial (FunctorAlg (Id_H _ _ BinCoproductsHSET s) has_homsets_HSET2).
 Proof.
 apply SignatureInitialAlgebra; try assumption.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -118,16 +118,13 @@ destruct n; simpl.
 + mkpair.
   * apply functor_identity.
   * apply θ_functor_identity.
-+ apply (θ_from_δ_Signature C hsC (DL_iter_functor1 C hsC (option_DistributiveLaw C hsC TC BCC) n)).
++ apply (θ_from_δ_Signature C hsC _ (DL_iter_functor1 C hsC (option_functor BCC TC) (option_DistributiveLaw C hsC TC BCC) n)).
 Defined.
 
 Lemma functor_in_precomp_option_iter_Signature_ok  (BCC : BinCoproducts C)
       (TC : Terminal C) (n : nat) : Signature_Functor _ _ _ _ (precomp_option_iter_Signature BCC TC n) = precomp_option_iter BCC TC n.
 Proof.
-destruct n; simpl.
-+ apply idpath.
-+ rewrite functor_in_DL_iter_functor1_ok.
-  apply idpath.
+destruct n; apply idpath.
 Qed.
 
 

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -114,15 +114,22 @@ Defined.
 Definition precomp_option_iter_Signature (BCC : BinCoproducts C)
   (TC : Terminal C) (n : nat) : Signature C hsC C hsC.
 Proof.
-mkpair.
-- apply (precomp_option_iter BCC TC n).
-- destruct n; simpl.
-  + apply θ_functor_identity.
-  + set (F := δ_iter_functor1 _ _ _ (δ_option _ hsC TC BCC)).
-    apply (θ_precompG _ hsC (iter_functor1 _ (option_functor BCC TC) n) (F n)).
-    * apply δ_law1_iter_functor1, δ_law1_option.
-    * apply δ_law2_iter_functor1, δ_law2_option.
+destruct n; simpl.
++ mkpair.
+  * apply functor_identity.
+  * apply θ_functor_identity.
++ apply (θ_from_δ_Signature C hsC (DL_iter_functor1 C hsC (precomp_option_DistributiveLaw C hsC TC BCC) n)).
 Defined.
+
+Lemma functor_in_precomp_option_iter_Signature_ok  (BCC : BinCoproducts C)
+      (TC : Terminal C) (n : nat) : Signature_Functor _ _ _ _ (precomp_option_iter_Signature BCC TC n) = precomp_option_iter BCC TC n.
+Proof.
+destruct n; simpl.
++ apply idpath.
++ rewrite functor_in_DL_iter_functor1_ok.
+  apply idpath.
+Qed.
+
 
 (* From here on all constructions need these hypotheses *)
 Context (BPC : BinProducts C) (BCC : BinCoproducts C).
@@ -146,9 +153,12 @@ destruct xs as [[|n] xs].
 - destruct xs; apply (is_omega_cocont_functor_identity has_homsets_C2).
 - induction n as [|n IHn].
   + destruct xs as [m []]; simpl.
+    unfold Arity_to_Signature. simpl.
+    rewrite functor_in_precomp_option_iter_Signature_ok.
     apply is_omega_cocont_precomp_option_iter, CLC.
   + destruct xs as [m [k xs]].
-    apply is_omega_cocont_BinProduct_of_Signatures.
+    apply is_omega_cocont_BinProduct_of_Signatures. simpl.
+    rewrite functor_in_precomp_option_iter_Signature_ok.
     * apply is_omega_cocont_precomp_option_iter, CLC.
     * apply (IHn (k,,xs)).
     * assumption.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad.v
@@ -118,7 +118,7 @@ destruct n; simpl.
 + mkpair.
   * apply functor_identity.
   * apply θ_functor_identity.
-+ apply (θ_from_δ_Signature C hsC (DL_iter_functor1 C hsC (precomp_option_DistributiveLaw C hsC TC BCC) n)).
++ apply (θ_from_δ_Signature C hsC (DL_iter_functor1 C hsC (option_DistributiveLaw C hsC TC BCC) n)).
 Defined.
 
 Lemma functor_in_precomp_option_iter_Signature_ok  (BCC : BinCoproducts C)

--- a/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
+++ b/UniMath/SubstitutionSystems/FromBindingSigsToMonads_Summary.v
@@ -58,30 +58,37 @@ Definition BindingSig : UU :=
   @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSig.
 
 (** Definition 4: Signatures with strength *)
-Definition Signature : ∏ C : precategory, has_homsets C → UU :=
+Definition Signature : ∏ C : precategory, has_homsets C → ∏ D : precategory, has_homsets D →UU :=
   @UniMath.SubstitutionSystems.Signatures.Signature.
 
 (** Definition 5: Morphism of signatures with strength *)
 Definition SignatureMor :
-  ∏ C : Precategory, Signature C (homset_property C) → Signature C (homset_property C) → UU :=
+  ∏ C D : Precategory,
+       Signatures.Signature C (homset_property C) D (homset_property D)
+       → Signatures.Signature C (homset_property C) D (homset_property D) → UU :=
   @UniMath.SubstitutionSystems.SignatureCategory.SignatureMor.
 
 (** Definition 6: Coproduct of signatures with strength *)
 Definition Sum_of_Signatures :
-  ∏ (I : UU) (C : precategory) (hsC : has_homsets C), Coproducts I C
-  → (I → Signature C hsC) → Signature C hsC :=
+  ∏ (I : UU) (C : precategory) (hsC : has_homsets C)
+       (D : precategory) (hsD : has_homsets D),
+       Coproducts I D
+       → (I → Signature C hsC D hsD) → Signature C hsC D hsD :=
     @UniMath.SubstitutionSystems.SumOfSignatures.Sum_of_Signatures.
 
 (** Definition 7: Binary product of signatures with strength *)
 Definition BinProduct_of_Signatures :
-  ∏ (C : precategory) (hsC : has_homsets C), BinProducts C
-  → Signature C hsC → Signature C hsC → Signature C hsC :=
+  ∏ (C : precategory) (hsC : has_homsets C) (D : precategory)
+       (hs : has_homsets D),
+       BinProducts D
+       → Signature C hsC D hs
+         → Signature C hsC D hs → Signature C hsC D hs :=
     @UniMath.SubstitutionSystems.BinProductOfSignatures.BinProduct_of_Signatures.
 
 (** Problem 8: Signatures with strength from binding signatures *)
 Definition BindingSigToSignature :
   ∏ {C : precategory} (hsC : has_homsets C), BinProducts C → BinCoproducts C → Terminal C
-  → ∏ sig : BindingSig, Coproducts (BindingSigIndex sig) C → Signature C hsC :=
+  → ∏ sig : BindingSig, Coproducts (BindingSigIndex sig) C → Signature C hsC C hsC :=
     @UniMath.SubstitutionSystems.BindingSigToMonad.BindingSigToSignature.
 
 (** Definition 10 and Lemma 11 and 12: see UniMath/SubstitutionSystems/SignatureExamples.v *)
@@ -342,7 +349,7 @@ Defined.
 Definition SignatureInitialAlgebra :
   ∏ {C : precategory} (hsC : has_homsets C) (BPC : BinProducts C) (BCC : BinCoproducts C),
   Initial C → Colims_of_shape nat_graph C
-  → ∏ s : Signature C hsC, is_omega_cocont (Signature_Functor C hsC s)
+  → ∏ s : Signature C hsC C hsC, is_omega_cocont (Signature_Functor C hsC C hsC s)
   → Initial (FunctorAlg (Id_H C hsC BCC s) (BindingSigToMonad.has_homsets_C2 hsC)).
 Proof.
 exact @UniMath.SubstitutionSystems.BindingSigToMonad.SignatureInitialAlgebra.
@@ -352,7 +359,7 @@ Defined.
 Definition InitHSS :
   ∏ (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C),
   BinProducts C → Initial C → Colims_of_shape nat_graph C →
-  ∏ H : Signature C hsC, is_omega_cocont (pr1 H) → hss_precategory CP H.
+  ∏ H : Signature C hsC C hsC, is_omega_cocont (pr1 H) → hss_precategory CP H.
 Proof.
 exact @UniMath.SubstitutionSystems.LiftingInitial_alt.InitHSS.
 Defined.
@@ -360,7 +367,7 @@ Defined.
 Lemma isInitial_InitHSS :
   ∏ (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C)
   (BPC : BinProducts C) (IC : Initial C)
-  (CC : Colims_of_shape nat_graph C) (H : Signature C hsC)
+  (CC : Colims_of_shape nat_graph C) (H : Signature C hsC C hsC)
   (HH : is_omega_cocont (pr1 H)),
   isInitial (hss_precategory CP H) (InitHSS C hsC CP BPC IC CC H HH).
 Proof.

--- a/UniMath/SubstitutionSystems/Lam.v
+++ b/UniMath/SubstitutionSystems/Lam.v
@@ -46,10 +46,10 @@ Require Import UniMath.SubstitutionSystems.MonadsFromSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.Notation.
 
 
-Arguments θ_source {_ _} _ .
-Arguments θ_target {_ _} _ .
-Arguments θ_Strength1 {_ _ _} _ .
-Arguments θ_Strength2 {_ _ _} _ .
+Arguments θ_source {_ _ _ _} _ .
+Arguments θ_target {_ _ _ _} _ .
+Arguments θ_Strength1 {_ _ _ _ _} _ .
+Arguments θ_Strength2 {_ _ _ _ _} _ .
 
 Section Lambda.
 
@@ -82,8 +82,8 @@ Variable KanExt : ∏ Z : precategory_Ptd C hs,
      (U Z) C hs hs.
 
 
-Let Lam_S : Signature _ _ := Lam_Sig C hs terminal CC CP.
-Let LamE_S : Signature _ _ := LamE_Sig C hs terminal CC CP.
+Let Lam_S : Signature _ _ _ _ := Lam_Sig C hs terminal CC CP.
+Let LamE_S : Signature _ _ _ _ := LamE_Sig C hs terminal CC CP.
 
 (* assume initial algebra for signature Lam *)
 
@@ -128,7 +128,7 @@ Defined.
 
 
 Definition Lam_App_Abs :  [C, C, hs]
-   ⟦ (H C hs CC (App_H C hs CP) (Abs_H C hs terminal CC)) `Lam , `Lam ⟧.
+   ⟦ (H C hs C hs CC (App_H C hs CP) (Abs_H C hs terminal CC)) `Lam , `Lam ⟧.
 Proof.
   exact (BinCoproductIn2 _ (BinCoproducts_functor_precat _ _ _ _ _ _) ;; alg_map _ Lam).
 Defined.

--- a/UniMath/SubstitutionSystems/LamFromBindingSig.v
+++ b/UniMath/SubstitutionSystems/LamFromBindingSig.v
@@ -46,8 +46,8 @@ Local Infix "::" := (@cons nat).
 Local Notation "[]" := (@nil nat) (at level 0, format "[]").
 Local Notation "'HSET2'":= [HSET, HSET, has_homsets_HSET].
 Local Notation "'Id'" := (functor_identity _).
-Local Notation "F * G" := (H HSET has_homsets_HSET BinProductsHSET F G).
-Local Notation "F + G" := (BinSumOfSignatures.H _ _ BinCoproductsHSET F G).
+Local Notation "F * G" := (H HSET has_homsets_HSET HSET has_homsets_HSET BinProductsHSET F G).
+Local Notation "F + G" := (BinSumOfSignatures.H _ _ _ _ BinCoproductsHSET F G).
 Local Notation "'_' 'o' 'option'" :=
   (ℓ (option_functor BinCoproductsHSET TerminalHSET)) (at level 10).
 
@@ -75,7 +75,7 @@ Definition LamSig : BindingSig :=
   mkBindingSig isdeceqbool (fun b => if b then 0 :: 0 :: [] else 1 :: [])%nat.
 
 (** The signature with strength for the lambda calculus *)
-Definition LamSignature : Signature HSET has_homsets_HSET :=
+Definition LamSignature : Signature HSET has_homsets_HSET _ _ :=
   BindingSigToSignatureHSET LamSig.
 
 Let Id_H := Id_H _ has_homsets_HSET BinCoproductsHSET.

--- a/UniMath/SubstitutionSystems/LamHSET.v
+++ b/UniMath/SubstitutionSystems/LamHSET.v
@@ -38,7 +38,7 @@ Require Import UniMath.CategoryTheory.CocontFunctors.
 
 Section LamHSET.
 
-Let Lam_S : Signature HSET has_homsets_HSET :=
+Let Lam_S : Signature HSET has_homsets_HSET _ _ :=
   Lam_Sig HSET has_homsets_HSET TerminalHSET BinCoproductsHSET BinProductsHSET.
 
 Local Notation "'EndHSET'":= ([HSET, HSET, has_homsets_HSET]) .

--- a/UniMath/SubstitutionSystems/LamSignature.v
+++ b/UniMath/SubstitutionSystems/LamSignature.v
@@ -42,10 +42,10 @@ Require Import UniMath.CategoryTheory.exponentials.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 
-Arguments θ_source {_ _} _ .
-Arguments θ_target {_ _} _ .
-Arguments θ_Strength1 {_ _ _} _ .
-Arguments θ_Strength2 {_ _ _} _ .
+Arguments θ_source {_ _ _ _} _ .
+Arguments θ_target {_ _ _ _} _ .
+Arguments θ_Strength1 {_ _ _ _ _} _ .
+Arguments θ_Strength2 {_ _ _ _ _} _ .
 
 Section Preparations.
 
@@ -637,7 +637,7 @@ Qed.
 
 (** finally, constitute the 3 signatures *)
 
-Definition App_Sig: Signature C hs.
+Definition App_Sig: Signature C hs C hs.
 Proof.
   exists App_H.
   exists App_θ.
@@ -646,7 +646,7 @@ Proof.
   + exact App_θ_strength2_int.
 Defined.
 
-Definition Abs_Sig: Signature C hs.
+Definition Abs_Sig: Signature C hs C hs.
 Proof.
   exists Abs_H.
   exists Abs_θ.
@@ -655,7 +655,7 @@ Proof.
   + exact Abs_θ_strength2_int.
 Defined.
 
-Definition Flat_Sig: Signature C hs.
+Definition Flat_Sig: Signature C hs C hs.
 Proof.
   exists Flat_H.
   exists Flat_θ.
@@ -664,12 +664,12 @@ Proof.
   + exact Flat_θ_strength2_int.
 Defined.
 
-Definition Lam_Sig: Signature C hs :=
-  BinSum_of_Signatures C hs CC App_Sig Abs_Sig.
+Definition Lam_Sig: Signature C hs C hs :=
+  BinSum_of_Signatures C hs C hs CC App_Sig Abs_Sig.
 
 Lemma is_omega_cocont_Lam
   (hE : ∏ x, is_omega_cocont (constprod_functor1 (BinProducts_functor_precat C C CP hs) x))
-  (LC : Colims_of_shape nat_graph C) : is_omega_cocont (Signature_Functor _ _ Lam_Sig).
+  (LC : Colims_of_shape nat_graph C) : is_omega_cocont (Signature_Functor _ _ _ _ Lam_Sig).
 Proof.
 apply is_omega_cocont_BinCoproduct_of_functors.
 - apply (BinProducts_functor_precat _ _ CP).
@@ -679,7 +679,7 @@ apply is_omega_cocont_BinCoproduct_of_functors.
 - apply (is_omega_cocont_Abs_H LC).
 Defined.
 
-Definition LamE_Sig: Signature C hs :=
-  BinSum_of_Signatures C hs CC Lam_Sig Flat_Sig.
+Definition LamE_Sig: Signature C hs C hs :=
+  BinSum_of_Signatures C hs C hs CC Lam_Sig Flat_Sig.
 
 End Lambda.

--- a/UniMath/SubstitutionSystems/LiftingInitial.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial.v
@@ -55,10 +55,10 @@ Require Import UniMath.SubstitutionSystems.Notation.
 Local Coercion alg_carrier : algebra_ob >-> ob.
 
 
-Arguments θ_source {_ _} _ .
-Arguments θ_target {_ _} _ .
-Arguments θ_Strength1 {_ _ _} _ .
-Arguments θ_Strength2 {_ _ _} _ .
+Arguments θ_source {_ _ _ _} _ .
+Arguments θ_target {_ _ _ _} _ .
+Arguments θ_Strength1 {_ _ _ _ _} _ .
+Arguments θ_Strength2 {_ _ _ _ _} _ .
 
 Section Precategory_Algebra.
 
@@ -80,7 +80,7 @@ Let CPEndEndC:= BinCoproducts_functor_precat _ _ CPEndC hsEndC: BinCoproducts En
 
 Variable KanExt : ∏ Z : Ptd, GlobalRightKanExtensionExists _ _ (U Z) _ hs hs.
 
-Variable H : Signature C hs.
+Variable H : Signature C hs C hs.
 Let θ := theta H.
 
 Definition Const_plus_H (X : EndC) : functor EndC EndC
@@ -843,7 +843,7 @@ Proof.
       fold θ.
       apply nat_trans_eq; try (exact hs).
       intro c.
-      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs H θ _ _ β Z c).
+      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hs _ hs H θ _ _ β Z c).
       eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].
       clear θ_nat_1_pointwise_inst.
       simpl.

--- a/UniMath/SubstitutionSystems/LiftingInitial_alt.v
+++ b/UniMath/SubstitutionSystems/LiftingInitial_alt.v
@@ -42,16 +42,16 @@ Require Import UniMath.SubstitutionSystems.Notation.
 
 Local Coercion alg_carrier : algebra_ob >-> ob.
 
-Arguments θ_source {_ _} _ .
-Arguments θ_target {_ _} _ .
-Arguments θ_Strength1 {_ _ _} _ .
-Arguments θ_Strength2 {_ _ _} _ .
+Arguments θ_source {_ _ _ _} _ .
+Arguments θ_target {_ _ _ _} _ .
+Arguments θ_Strength1 {_ _ _ _ _} _ .
+Arguments θ_Strength2 {_ _ _ _ _} _ .
 
 Section Precategory_Algebra.
 
 Variables (C : precategory) (hsC : has_homsets C) (CP : BinCoproducts C) (BPC : BinProducts C).
 Variables (IC : Initial C) (CC : Colims_of_shape nat_graph C).
-Variables (H : Signature C hsC) (HH : is_omega_cocont H).
+Variables (H : Signature C hsC C hsC) (HH : is_omega_cocont H).
 
 Local Notation "'EndC'":= ([C, C, hsC]) .
 Local Notation "'Ptd'" := (precategory_Ptd C hsC).
@@ -629,7 +629,7 @@ pathvia (pr1 (pr1 X)).
       rewrite assoc.
       apply cancel_postcomposition.
       apply (nat_trans_eq hsC); intro c.
-      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hsC H θ _ _ β Z c).
+      assert (θ_nat_1_pointwise_inst := θ_nat_1_pointwise _ hsC _ hsC H θ _ _ β Z c).
       eapply pathscomp0 ; [exact θ_nat_1_pointwise_inst | ].
       clear θ_nat_1_pointwise_inst.
       simpl.

--- a/UniMath/SubstitutionSystems/MLTT79.v
+++ b/UniMath/SubstitutionSystems/MLTT79.v
@@ -186,7 +186,7 @@ Definition WSig : BindingSig :=
 
 Definition USig : BindingSig := mkBindingSig isdeceqnat (fun _ => []).
 
-Let SigHSET := Signature HSET has_homsets_HSET.
+Let SigHSET := Signature HSET has_homsets_HSET HSET has_homsets_HSET.
 
 (** The binding signature of MLTT79 *)
 Definition MLTT79Sig := PiSig ++ SigmaSig ++ SumSig ++ IdSig ++

--- a/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/MonadsFromSubstitutionSystems.v
@@ -58,12 +58,12 @@ Local Notation "'EndC'":= ([C, C, hs]) .
 Let hsEndC : has_homsets EndC := functor_category_has_homsets C C hs.
 Let CPEndC : BinCoproducts EndC := BinCoproducts_functor_precat _ _ CP hs.
 
-Variable H : Signature C hs.
+Variable H : Signature C hs C hs.
 
 Let θ := theta H.
 
-Let θ_strength1_int := Sig_strength_law1 _ _ H.
-Let θ_strength2_int := Sig_strength_law2 _ _ H.
+Let θ_strength1_int := Sig_strength_law1 _ _ _ _ H.
+Let θ_strength2_int := Sig_strength_law2 _ _ _ _ H.
 
 Let Id_H
 : functor EndC EndC
@@ -119,7 +119,7 @@ Proof.
   - apply nat_trans_eq; try assumption.
     intro c. simpl.
     rewrite id_right.
-    assert (H':= θ_Strength1_int_implies_θ_Strength1 _ _ _ _ θ_strength1_int).
+    assert (H':= θ_Strength1_int_implies_θ_Strength1 _ _ _ _ _ _ θ_strength1_int).
     red in H'. simpl in H'.
     assert (H2 := H' (`T)).
     assert (H3 := nat_trans_eq_pointwise H2 c).
@@ -233,7 +233,7 @@ Proof.
       apply cancel_postcomposition.
       apply cancel_postcomposition.
       apply cancel_postcomposition.
-      assert (H':=θ_nat_2 _ _ H θ).
+      assert (H':=θ_nat_2 _ _ _ _ H θ).
       assert (H2 := H' (`T) _ _ μ_0_ptd); clear H'.
       assert (H3:= nat_trans_eq_weq hs _ _ H2 c); clear H2.
       simpl in H3.
@@ -330,7 +330,7 @@ Proof.
       apply pathsinv0.
       apply maponpaths. apply Monad_law_1_from_hss.
   - rewrite functor_comp.
-    assert (H1 := θ_nat_2 _ _ H θ (`T) _ _ μ_2_ptd).
+    assert (H1 := θ_nat_2 _ _ _ _ H θ (`T) _ _ μ_2_ptd).
     simpl in H1.
     repeat rewrite assoc.
     match goal with |[H1 : ?g = _ |- _ ;; _ ;; ?f ;; ?h = _ ] =>
@@ -423,7 +423,7 @@ Lemma μ_3_μ_2_T_μ_2 :  (
     unfold θ_target_ob in *.
     simpl in *.
     unfold functor_compose in *.
-    assert (HX:=θ_nat_1 _ _ H θ _ _ μ_2).  (* it may be tested with the primed version *)
+    assert (HX:=θ_nat_1 _ _ _ _ H θ _ _ μ_2).  (* it may be tested with the primed version *)
     assert (HX1:= HX (ptd_from_alg T)); clear HX.
     simpl in HX1.
     assert (HXX:=nat_trans_eq_pointwise HX1 c); clear HX1.
@@ -448,7 +448,7 @@ Lemma μ_3_μ_2_T_μ_2 :  (
                      pr1 (θ (( ((`T) • (`T) : [_, _, hs])) ⊗ (ptd_from_alg T))) c;;
                      pr1 (# H (α : functor_compose hs hs (`T) (functor_composite (`T) (` T))--> _)) c       ).
       { (intro α;
-          assert (HA := θ_Strength2_int_implies_θ_Strength2 _ _ _ _ θ_strength2_int);
+          assert (HA := θ_Strength2_int_implies_θ_Strength2 _ _ _ _ _ _ θ_strength2_int);
           assert (HA':= HA (`T) (ptd_from_alg T) (ptd_from_alg T) _ α); clear HA;
           assert (HA2 := nat_trans_eq_pointwise HA' c ); clear HA';
           simpl in HA2; apply HA2 ).
@@ -541,7 +541,7 @@ Proof.
     + clear HX'.
       rewrite id_left.
       rewrite id_right.
-      assert (HX:=θ_nat_1 _ _ H θ _ _ μ_2).
+      assert (HX:=θ_nat_1 _ _ _ _ H θ _ _ μ_2).
       assert (HX1:= HX (ptd_from_alg T)); clear HX.
       simpl in HX1.
       assert (HXX:=nat_trans_eq_pointwise HX1 x); clear HX1.

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -122,17 +122,15 @@ mkpair.
             apply subtypeEquality; try (intro x; apply has_homsets_HSET)).
 Defined.
 
-Definition sorted_variable (s: sort) : SET / sort.
+(** The object (1,λ _,s) in SET/sort that can be seen as a sorted variable *)
+Local Definition constHSET_slice (s : sort) : SET / sort.
 Proof.
-  mkpair.
-  + mkpair.
-   - exact unit.
-   - apply isasetunit.
-  + intros _. exact s.
+exists (TerminalObject TerminalHSET); simpl.
+apply (λ x, s).
 Defined.
 
 Definition sorted_option_functor (s : sort) : functor (SET / sort) (SET / sort) :=
-  constcoprod_functor1 BinCoproducts_SET_div_sort (sorted_variable s).
+  constcoprod_functor1 BinCoproducts_SET_div_sort (constHSET_slice s).
 
 (** sorted option functor for lists (also called option in the note) *)
 Local Definition option_list (xs : list sort) : functor (SET / sort) (SET / sort).
@@ -192,13 +190,6 @@ End functor.
 
 (** * Proof that the functor obtained from a multisorted signature is omega-cocontinuous *)
 Section omega_cocont.
-
-(** The object (1,λ _,s) in SET/sort *)
-Local Definition constHSET_slice (s : sort) : SET / sort.
-Proof.
-exists (TerminalObject TerminalHSET); simpl.
-apply (λ x, s).
-Defined.
 
 (** The proj functor is naturally isomorphic to the following functor which is a left adjoint: *)
 Local Definition proj_functor' (s : sort) : functor (SET / sort) SET :=

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -69,6 +69,19 @@ exists (SET / sort).
 now apply has_homsets_slice_precat.
 Defined.
 
+(* will not be needed: *)
+Local Definition BinCoproducts_SET_over_sort: BinCoproducts SET_over_sort.
+Proof.
+apply BinCoproducts_slice_precat.
+exact BinCoproductsHSET.
+Defined.
+
+Local Definition BinCoproducts_SET_div_sort: BinCoproducts (SET / sort).
+Proof.
+apply BinCoproducts_slice_precat.
+exact BinCoproductsHSET.
+Defined.
+
 Let post_comp := post_composition_functor (SET / sort) _ _
                    (homset_property SET_over_sort) has_homsets_HSET.
 
@@ -109,44 +122,24 @@ mkpair.
             apply subtypeEquality; try (intro x; apply has_homsets_HSET)).
 Defined.
 
-Local Definition option_fun : sort -> SET / sort -> SET / sort.
+Definition sorted_variable (s: sort) : SET / sort.
 Proof.
-  simpl; intros s Xf.
   mkpair.
   + mkpair.
-    - exact (pr1 (pr1 Xf) ⨿ unit).
-    - apply isasetcoprod; [apply setproperty| apply isasetunit].
-  + exact (sumofmaps (pr2 Xf) (termfun s)).
+   - exact unit.
+   - apply isasetunit.
+  + intros _. exact s.
 Defined.
 
-Local Definition option_functor_data (s : sort) : functor_data (SET / sort) (SET / sort).
-Proof.
-exists (option_fun s).
-intros X Y f.
-mkpair.
-- intros F.
-  induction F as [t|t]; [apply (ii1 (pr1 f t)) | apply (ii2 t)].
-- abstract (apply funextsec; intros [t|t]; trivial; apply (toforallpaths _ _ _ (pr2 f) t)).
-Defined.
+Definition sorted_option_functor (s : sort) : functor (SET / sort) (SET / sort) :=
+  constcoprod_functor1 BinCoproducts_SET_div_sort (sorted_variable s).
 
-Local Lemma is_functor_option_functor (s : sort) : is_functor (option_functor_data s).
-Proof.
-split; simpl.
-+ intros X; apply (eq_mor_slicecat has_homsets_HSET), funextsec; intros t.
-  now induction t.
-+ intros X Y Z f g; apply (eq_mor_slicecat has_homsets_HSET), funextsec; intros t.
-  now induction t.
-Qed.
-
-Local Definition option_functor (s : sort) : functor (SET / sort) (SET / sort) :=
-  tpair _ _ (is_functor_option_functor s).
-
-(** option_functor for lists (also called option in the note) *)
+(** sorted option functor for lists (also called option in the note) *)
 Local Definition option_list (xs : list sort) : functor (SET / sort) (SET / sort).
 Proof.
 use (foldr _ _ xs).
 + intros s F.
-  apply (functor_composite (option_functor s) F).
+  apply (functor_composite (sorted_option_functor s) F).
 + apply functor_identity.
 Defined.
 

--- a/UniMath/SubstitutionSystems/MultiSorted.v
+++ b/UniMath/SubstitutionSystems/MultiSorted.v
@@ -69,19 +69,6 @@ exists (SET / sort).
 now apply has_homsets_slice_precat.
 Defined.
 
-(* will not be needed: *)
-Local Definition BinCoproducts_SET_over_sort: BinCoproducts SET_over_sort.
-Proof.
-apply BinCoproducts_slice_precat.
-exact BinCoproductsHSET.
-Defined.
-
-Local Definition BinCoproducts_SET_div_sort: BinCoproducts (SET / sort).
-Proof.
-apply BinCoproducts_slice_precat.
-exact BinCoproductsHSET.
-Defined.
-
 Let post_comp := post_composition_functor (SET / sort) _ _
                    (homset_property SET_over_sort) has_homsets_HSET.
 
@@ -130,7 +117,7 @@ apply (λ x, s).
 Defined.
 
 Definition sorted_option_functor (s : sort) : functor (SET / sort) (SET / sort) :=
-  constcoprod_functor1 BinCoproducts_SET_div_sort (constHSET_slice s).
+  constcoprod_functor1 (BinCoproducts_HSET_slice sort) (constHSET_slice s).
 
 (** sorted option functor for lists (also called option in the note) *)
 Local Definition option_list (xs : list sort) : functor (SET / sort) (SET / sort).

--- a/UniMath/SubstitutionSystems/SignatureCategory.v
+++ b/UniMath/SubstitutionSystems/SignatureCategory.v
@@ -32,9 +32,10 @@ Local Notation "[ C , D ]" := (functor_Precategory C D).
 (** * The category of signatures with strength *)
 Section SignatureCategory.
 
-Variables (C : Precategory).
+Variables (C D : Precategory).
 
 Let hsC : has_homsets C := homset_property C.
+Let hsD : has_homsets D := homset_property D.
 
 Local Notation "'U'" := (functor_ptd_forget C hsC).
 Local Notation "'Ptd'" := (precategory_Ptd C hsC).
@@ -42,21 +43,21 @@ Local Notation "'Ptd'" := (precategory_Ptd C hsC).
 (** Define the commutative diagram used in the morphisms *)
 Section Signature_category_mor.
 
-Variables (Ht Ht' : Signature C hsC).
+Variables (Ht Ht' : Signature C hsC D hsD).
 
-Let H := Signature_Functor _ _ Ht.
-Let H' := Signature_Functor _ _ Ht'.
+Let H := Signature_Functor _ _ _ _ Ht.
+Let H' := Signature_Functor _ _ _ _ Ht'.
 Let θ : nat_trans (θ_source Ht) (θ_target Ht) := theta Ht.
 Let θ' : nat_trans (θ_source Ht') (θ_target Ht') := theta Ht'.
 
 Variables (α : nat_trans H H').
 Variables (X : [C,C]) (Y : Ptd).
 
-Let f1 : [C,C] ⟦H X • U Y,H (X • U Y)⟧ := θ (X,,Y).
-Let f2 : [C,C] ⟦H (X • U Y),H' (X • U Y)⟧ := α (X • U Y).
+Let f1 : [C,D] ⟦H X • U Y,H (X • U Y)⟧ := θ (X,,Y).
+Let f2 : [C,D] ⟦H (X • U Y),H' (X • U Y)⟧ := α (X • U Y).
 
-Let g1 : [C,C] ⟦H X • U Y,H' X • U Y⟧ := α X ∙∙ identity (U Y).
-Let g2 : [C,C] ⟦H' X • U Y,H' (X • U Y)⟧ := θ' (X,,Y).
+Let g1 : [C,D] ⟦H X • U Y,H' X • U Y⟧ := α X ∙∙ identity (U Y).
+Let g2 : [C,D] ⟦H' X • U Y,H' (X • U Y)⟧ := θ' (X,,Y).
 
 Definition Signature_category_mor_diagram : UU := f1 ;; f2 = g1 ;; g2.
 
@@ -65,13 +66,13 @@ Lemma Signature_category_mor_diagram_pointwise
   (Hc : ∏ c, pr1 f1 c ;; pr1 f2 c = pr1 (α X) ((pr1 Y) c) ;; pr1 g2 c) :
    Signature_category_mor_diagram.
 Proof.
-apply (nat_trans_eq hsC); intro c; simpl.
+apply (nat_trans_eq hsD); intro c; simpl.
 rewrite functor_id, id_right; apply (Hc c).
 Qed.
 
 End Signature_category_mor.
 
-Definition SignatureMor : Signature C hsC → Signature C hsC → UU.
+Definition SignatureMor : Signature C hsC D hsD → Signature C hsC D hsD → UU.
 Proof.
 intros Ht Ht'.
 use total2.
@@ -79,7 +80,7 @@ use total2.
 + intros α; apply (∏ X Y, Signature_category_mor_diagram Ht Ht' α X Y).
 Defined.
 
-Lemma SignatureMor_eq (Ht Ht' : Signature C hsC) (f g : SignatureMor Ht Ht') :
+Lemma SignatureMor_eq (Ht Ht' : Signature C hsC D hsD) (f g : SignatureMor Ht Ht') :
   pr1 f = pr1 g -> f = g.
 Proof.
 intros H.
@@ -87,17 +88,17 @@ apply subtypeEquality; trivial.
 now intros α; repeat (apply impred; intro); apply functor_category_has_homsets.
 Qed.
 
-Local Lemma SignatureMor_id_subproof (Ht : Signature C hsC) X Y :
+Local Lemma SignatureMor_id_subproof (Ht : Signature C hsC D hsD) X Y :
   Signature_category_mor_diagram Ht Ht (nat_trans_id Ht) X Y.
 Proof.
 apply Signature_category_mor_diagram_pointwise; intro c; simpl.
 now rewrite id_left, id_right.
 Qed.
 
-Definition SignatureMor_id (Ht : Signature C hsC) : SignatureMor Ht Ht :=
+Definition SignatureMor_id (Ht : Signature C hsC D hsD) : SignatureMor Ht Ht :=
   (nat_trans_id Ht,,SignatureMor_id_subproof Ht).
 
-Definition SignatureMor_comp_subproof (Ht1 Ht2 Ht3 : Signature C hsC)
+Definition SignatureMor_comp_subproof (Ht1 Ht2 Ht3 : Signature C hsC D hsD)
   (α : SignatureMor Ht1 Ht2) (β : SignatureMor Ht2 Ht3) X Y :
   Signature_category_mor_diagram Ht1 Ht3 (nat_trans_comp (pr1 α) (pr1 β)) X Y.
 Proof.
@@ -106,18 +107,18 @@ unfold Signature_category_mor_diagram in *; simpl.
 rewrite (assoc ((theta Ht1) (X,,Y))).
 etrans; [apply (cancel_postcomposition _ _ _ _ ((theta Ht1) (X,,Y) ;; _)), Hα|].
 rewrite <- assoc; etrans; [apply maponpaths, Hβ|].
-rewrite assoc; apply (cancel_postcomposition [C,C] _ _ _ _ (_ ∙∙ identity (U Y))).
-apply (nat_trans_eq hsC); intro c; simpl.
+rewrite assoc; apply (cancel_postcomposition [C,D] _ _ _ _ (_ ∙∙ identity (U Y))).
+apply (nat_trans_eq hsD); intro c; simpl.
 now rewrite assoc, !functor_id, !id_right.
 Qed.
 
-Definition SignatureMor_comp (Ht1 Ht2 Ht3 : Signature C hsC)
+Definition SignatureMor_comp (Ht1 Ht2 Ht3 : Signature C hsC D hsD)
   (α : SignatureMor Ht1 Ht2) (β : SignatureMor Ht2 Ht3) : SignatureMor Ht1 Ht3 :=
     (nat_trans_comp (pr1 α) (pr1 β),,SignatureMor_comp_subproof Ht1 Ht2 Ht3 α β).
 
 Definition Signature_precategory_data : precategory_data.
 Proof.
-apply (tpair _ (Signature C hsC,,SignatureMor)), (SignatureMor_id,,SignatureMor_comp).
+apply (tpair _ (Signature C hsC D hsD,,SignatureMor)), (SignatureMor_id,,SignatureMor_comp).
 Defined.
 
 Lemma is_precategory_Signature_precategory_data :
@@ -125,11 +126,11 @@ Lemma is_precategory_Signature_precategory_data :
 Proof.
 repeat split; simpl.
 - intros Ht Ht' F; apply SignatureMor_eq; simpl.
-  apply (nat_trans_eq (functor_category_has_homsets _ _ hsC)); intros X; apply id_left.
+  apply (nat_trans_eq (functor_category_has_homsets _ _ hsD)); intros X; apply id_left.
 - intros Ht Ht' F; apply SignatureMor_eq; simpl.
-  apply (nat_trans_eq (functor_category_has_homsets _ _ hsC)); intros X; apply id_right.
+  apply (nat_trans_eq (functor_category_has_homsets _ _ hsD)); intros X; apply id_right.
 - intros Ht1 Ht2 Ht3 Ht4 F1 F2 F3; apply SignatureMor_eq; simpl.
-  apply (nat_trans_eq (functor_category_has_homsets _ _ hsC)); intros X; apply assoc.
+  apply (nat_trans_eq (functor_category_has_homsets _ _ hsD)); intros X; apply assoc.
 Qed.
 
 Definition Signature_precategory : precategory :=
@@ -146,11 +147,11 @@ apply (isofhleveltotal2 2).
   apply functor_category_has_homsets.
 Qed.
 
-Definition SignatureForgetfulFunctor : functor Signature_precategory [[C,C],[C,C]].
+Definition SignatureForgetfulFunctor : functor Signature_precategory [[C,C],[C,D]].
 Proof.
 mkpair.
 - mkpair.
-  + intros F; apply(Signature_Functor _ _ F).
+  + intros F; apply(Signature_Functor _ _ _ _ F).
   + intros F G α; apply α.
 - abstract (now split).
 Defined.
@@ -169,49 +170,50 @@ End SignatureCategory.
 (** * Binary products in the category of signatures *)
 Section BinProducts.
 
-Variables (C : Precategory) (BC : BinProducts C).
+Variables (C : Precategory) (BC : BinProducts C) (D : Precategory) (BD : BinProducts D).
 
 Let hsC : has_homsets C := homset_property C.
+Let hsD : has_homsets D := homset_property D.
 
-Local Definition BCC : BinProducts [[C,C],[C,C]].
+Local Definition BCD : BinProducts [[C,C],[C,D]].
 Proof.
-apply BinProducts_functor_precat, (BinProducts_functor_precat C _ BC).
+apply BinProducts_functor_precat, (BinProducts_functor_precat C _ BD).
 Defined.
 
-Local Lemma Signature_precategory_pr1_diagram (Ht1 Ht2 : Signature C hsC) X Y :
-  Signature_category_mor_diagram _ (BinProduct_of_Signatures _ _ _ Ht1 Ht2) _
-    (BinProductPr1 _ (BCC _ _)) X Y.
+Local Lemma Signature_precategory_pr1_diagram (Ht1 Ht2 : Signature C hsC D hsD) X Y :
+  Signature_category_mor_diagram _ _ (BinProduct_of_Signatures _ _ _ _ _ Ht1 Ht2) _
+    (BinProductPr1 _ (BCD _ _)) X Y.
 Proof.
 apply Signature_category_mor_diagram_pointwise; intro c; apply BinProductOfArrowsPr1.
 Qed.
 
-Local Definition Signature_precategory_pr1 (Ht1 Ht2 : Signature C hsC) :
-  SignatureMor C (BinProduct_of_Signatures C hsC BC Ht1 Ht2) Ht1.
+Local Definition Signature_precategory_pr1 (Ht1 Ht2 : Signature C hsC D hsD) :
+  SignatureMor C D (BinProduct_of_Signatures C hsC D hsD BD Ht1 Ht2) Ht1.
 Proof.
 mkpair.
-+ apply (BinProductPr1 _ (BCC (pr1 Ht1) (pr1 Ht2))).
++ apply (BinProductPr1 _ (BCD (pr1 Ht1) (pr1 Ht2))).
 + apply Signature_precategory_pr1_diagram.
 Defined.
 
-Local Lemma Signature_precategory_pr2_diagram (Ht1 Ht2 : Signature C hsC) X Y :
-  Signature_category_mor_diagram _ (BinProduct_of_Signatures _ _ _ Ht1 Ht2) _
-    (BinProductPr2 _ (BCC _ _)) X Y.
+Local Lemma Signature_precategory_pr2_diagram (Ht1 Ht2 : Signature C hsC D hsD) X Y :
+  Signature_category_mor_diagram _ _ (BinProduct_of_Signatures _ _ _ _ _ Ht1 Ht2) _
+    (BinProductPr2 _ (BCD _ _)) X Y.
 Proof.
 apply Signature_category_mor_diagram_pointwise; intro c; apply BinProductOfArrowsPr2.
 Qed.
 
-Local Definition Signature_precategory_pr2 (Ht1 Ht2 : Signature C hsC) :
-  SignatureMor C (BinProduct_of_Signatures C hsC BC Ht1 Ht2) Ht2.
+Local Definition Signature_precategory_pr2 (Ht1 Ht2 : Signature C hsC D hsD) :
+  SignatureMor C D (BinProduct_of_Signatures C hsC D hsD BD Ht1 Ht2) Ht2.
 Proof.
 mkpair.
-+ apply (BinProductPr2 _ (BCC (pr1 Ht1) (pr1 Ht2))).
++ apply (BinProductPr2 _ (BCD (pr1 Ht1) (pr1 Ht2))).
 + apply Signature_precategory_pr2_diagram.
 Defined.
 
 Local Lemma BinProductArrow_diagram Ht1 Ht2 Ht3
-  (F : SignatureMor C Ht3 Ht1) (G : SignatureMor C Ht3 Ht2) X Y :
-  Signature_category_mor_diagram _ _ (BinProduct_of_Signatures _ _ _ Ht1 Ht2)
-    (BinProductArrow _ (BCC _ _) (pr1 F) (pr1 G)) X Y.
+  (F : SignatureMor C D Ht3 Ht1) (G : SignatureMor C D Ht3 Ht2) X Y :
+  Signature_category_mor_diagram _ _ _ (BinProduct_of_Signatures _ _ _ _ _ Ht1 Ht2)
+    (BinProductArrow _ (BCD _ _) (pr1 F) (pr1 G)) X Y.
 Proof.
 apply Signature_category_mor_diagram_pointwise; intro c.
 apply pathsinv0.
@@ -225,30 +227,30 @@ apply pathsinv0, BinProductArrowUnique; rewrite <- assoc.
   now etrans; [apply cancel_postcomposition, horcomp_id_left|].
 Qed.
 
-Local Lemma isBinProductCone_Signature_precategory (Ht1 Ht2 : Signature C hsC) :
-  isBinProductCone (Signature_precategory C) Ht1 Ht2
-                   (BinProduct_of_Signatures C hsC BC Ht1 Ht2)
+Local Lemma isBinProductCone_Signature_precategory (Ht1 Ht2 : Signature C hsC D hsD) :
+  isBinProductCone (Signature_precategory C D) Ht1 Ht2
+                   (BinProduct_of_Signatures C hsC D hsD BD Ht1 Ht2)
                    (Signature_precategory_pr1 Ht1 Ht2) (Signature_precategory_pr2 Ht1 Ht2).
 Proof.
-apply (mk_isBinProductCone _ (has_homsets_Signature_precategory C)).
+apply (mk_isBinProductCone _ (has_homsets_Signature_precategory C D)).
 simpl; intros Ht3 F G.
 use unique_exists; simpl.
-- apply (tpair _ (BinProductArrow _ (BCC (pr1 Ht1) (pr1 Ht2)) (pr1 F) (pr1 G))).
+- apply (tpair _ (BinProductArrow _ (BCD (pr1 Ht1) (pr1 Ht2)) (pr1 F) (pr1 G))).
   apply BinProductArrow_diagram.
 - abstract (split;
-    [ apply SignatureMor_eq, (BinProductPr1Commutes _ _ _ (BCC  _ _))
-    | apply SignatureMor_eq, (BinProductPr2Commutes _ _ _ (BCC  _ _))]).
+    [ apply SignatureMor_eq, (BinProductPr1Commutes _ _ _ (BCD  _ _))
+    | apply SignatureMor_eq, (BinProductPr2Commutes _ _ _ (BCD  _ _))]).
 - abstract (intros X; apply isapropdirprod; apply has_homsets_Signature_precategory).
 - abstract (intros X H1H2; apply SignatureMor_eq; simpl;
-    apply (BinProductArrowUnique _ _ _ (BCC  _ _));
+    apply (BinProductArrowUnique _ _ _ (BCD  _ _));
       [ apply (maponpaths pr1 (pr1 H1H2)) | apply (maponpaths pr1 (pr2 H1H2)) ]).
 Defined.
 
-Lemma BinProducts_Signature_precategory : BinProducts (Signature_precategory C).
+Lemma BinProducts_Signature_precategory : BinProducts (Signature_precategory C D).
 Proof.
 intros Ht1 Ht2.
 use mk_BinProductCone.
-- apply (BinProduct_of_Signatures _ _ BC Ht1 Ht2).
+- apply (BinProduct_of_Signatures _ _ _ _ BD Ht1 Ht2).
 - apply Signature_precategory_pr1.
 - apply Signature_precategory_pr2.
 - apply isBinProductCone_Signature_precategory.
@@ -260,70 +262,71 @@ End BinProducts.
 Section Coproducts.
 
 Variables (I : UU) (HI : isdeceq I).
-Variables (C : Precategory) (CC : Coproducts I C).
+Variables (C D : Precategory) (CD : Coproducts I D).
 
 Let hsC : has_homsets C := homset_property C.
+Let hsD : has_homsets D := homset_property D.
 
-Local Definition CCC : Coproducts I [[C,C],[C,C]].
+Local Definition CCD : Coproducts I [[C,C],[C,D]].
 Proof.
 now repeat apply Coproducts_functor_precat.
 Defined.
 
-Local Lemma Signature_precategory_in_diagram (Ht : I → Signature_precategory C) i X Y :
-  Signature_category_mor_diagram _ _ (Sum_of_Signatures I C _ CC Ht)
-    (CoproductIn _ _ (CCC (λ j : I, pr1 (Ht j))) i) X Y.
+Local Lemma Signature_precategory_in_diagram (Ht : I → Signature_precategory C D) i X Y :
+  Signature_category_mor_diagram _ _ _ (Sum_of_Signatures I C _ _ _ CD Ht)
+    (CoproductIn _ _ (CCD (λ j : I, pr1 (Ht j))) i) X Y.
 Proof.
 apply Signature_category_mor_diagram_pointwise; intro c.
 apply pathsinv0.
-set (C1 := CC (λ j, pr1 (pr1 (Ht j) X) ((pr1 Y) c))).
-set (C2 := CC (λ j, pr1 (pr1 (Ht j) (functor_composite (pr1 Y) X)) c)).
-apply (@CoproductOfArrowsIn I C _ C1 _ C2).
+set (C1 := CD (λ j, pr1 (pr1 (Ht j) X) ((pr1 Y) c))).
+set (C2 := CD (λ j, pr1 (pr1 (Ht j) (functor_composite (pr1 Y) X)) c)).
+apply (@CoproductOfArrowsIn I D _ C1 _ C2).
 Defined.
 
-Local Definition Signature_precategory_in (Ht : I → Signature_precategory C) (i : I) :
-  SignatureMor C (Ht i) (Sum_of_Signatures I C _ CC Ht).
+Local Definition Signature_precategory_in (Ht : I → Signature_precategory C D) (i : I) :
+  SignatureMor C D (Ht i) (Sum_of_Signatures I C _ D _ CD Ht).
 Proof.
 mkpair.
-+ apply (CoproductIn _ _ (CCC (λ j, pr1 (Ht j))) i).
++ apply (CoproductIn _ _ (CCD (λ j, pr1 (Ht j))) i).
 + apply Signature_precategory_in_diagram.
 Defined.
 
-Lemma CoproductArrow_diagram (Hti : I → Signature_precategory C)
-  (Ht : Signature C hsC) (F : ∏ i : I, SignatureMor C (Hti i) Ht) X Y :
-  Signature_category_mor_diagram C (Sum_of_Signatures I C hsC CC Hti) Ht
-    (CoproductArrow I _ (CCC _) (λ i, pr1 (F i))) X Y.
+Lemma CoproductArrow_diagram (Hti : I → Signature_precategory C D)
+  (Ht : Signature C hsC D hsD) (F : ∏ i : I, SignatureMor C D (Hti i) Ht) X Y :
+  Signature_category_mor_diagram C D (Sum_of_Signatures I C hsC D hsD CD Hti) Ht
+    (CoproductArrow I _ (CCD _) (λ i, pr1 (F i))) X Y.
 Proof.
 apply Signature_category_mor_diagram_pointwise; intro c.
 etrans; [apply precompWithCoproductArrow|].
 apply pathsinv0, CoproductArrowUnique; intro i; rewrite assoc; simpl.
 etrans;
-  [apply cancel_postcomposition, (CoproductInCommutes _ _ _ (CC (λ j, pr1 (pr1 (Hti j) X) _)))|].
+  [apply cancel_postcomposition, (CoproductInCommutes _ _ _ (CD (λ j, pr1 (pr1 (Hti j) X) _)))|].
 apply pathsinv0; etrans; [apply (nat_trans_eq_pointwise (pr2 (F i) X Y) c)|].
 now etrans; [apply cancel_postcomposition, horcomp_id_left|].
 Qed.
 
-Local Lemma isCoproductCocone_Signature_precategory (Hti : I → Signature_precategory C) :
-  isCoproductCocone I (Signature_precategory C) _
-    (Sum_of_Signatures I C hsC CC Hti) (Signature_precategory_in Hti).
+Local Lemma isCoproductCocone_Signature_precategory (Hti : I → Signature_precategory C D) :
+  isCoproductCocone I (Signature_precategory C D) _
+    (Sum_of_Signatures I C hsC D hsD CD Hti) (Signature_precategory_in Hti).
 Proof.
-apply (mk_isCoproductCocone _ _ (has_homsets_Signature_precategory C)); simpl.
+apply (mk_isCoproductCocone _ _ (has_homsets_Signature_precategory C D)); simpl.
 intros Ht F.
 use unique_exists; simpl.
 + mkpair.
-  - apply (CoproductArrow I _ (CCC (λ j, pr1 (Hti j))) (λ i, pr1 (F i))).
+  - apply (CoproductArrow I _ (CCD (λ j, pr1 (Hti j))) (λ i, pr1 (F i))).
   - apply CoproductArrow_diagram.
-+ abstract (intro i; apply SignatureMor_eq, (CoproductInCommutes _ _ _ (CCC (λ j, pr1 (Hti j))))).
++ abstract (intro i; apply SignatureMor_eq, (CoproductInCommutes _ _ _ (CCD (λ j, pr1 (Hti j))))).
 + abstract (intros X; apply impred; intro i; apply has_homsets_Signature_precategory).
 + abstract (intros X Hi;  apply SignatureMor_eq; simpl;
-            apply (CoproductArrowUnique _ _ _ (CCC (λ j, pr1 (Hti j)))); intro i;
+            apply (CoproductArrowUnique _ _ _ (CCD (λ j, pr1 (Hti j)))); intro i;
             apply (maponpaths pr1 (Hi i))).
 Defined.
 
-Lemma Coproducts_Signature_precategory : Coproducts I (Signature_precategory C).
+Lemma Coproducts_Signature_precategory : Coproducts I (Signature_precategory C D).
 Proof.
 intros Ht.
 use mk_CoproductCocone.
-- apply (Sum_of_Signatures I _ _ CC Ht).
+- apply (Sum_of_Signatures I _ _ _ _ CD Ht).
 - apply Signature_precategory_in.
 - apply isCoproductCocone_Signature_precategory.
 Defined.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -160,7 +160,7 @@ Definition θ_precompG : ∑ θ : θ_source precompG ⟶ θ_target precompG,
                               θ_Strength1_int θ × θ_Strength2_int θ :=
   tpair _ θ_from_δ (θ_Strength1_int_from_δ,,θ_Strength2_int_from_δ).
 
-Definition θ_from_δ_Signature : Signature C hsC :=
+Definition θ_from_δ_Signature : Signature C hsC C hsC :=
   tpair _ precompG θ_precompG.
 
 End θ_from_δ.
@@ -358,7 +358,7 @@ apply pathsinv0, BinCoproductArrowUnique.
   now apply maponpaths, BinCoproductIn2Commutes.
 Qed.
 
-Definition precomp_genoption_Signature : Signature C hsC :=
+Definition precomp_genoption_Signature : Signature C hsC C hsC :=
   θ_from_δ_Signature _ hsC genopt δ_genoption δ_law1_genoption δ_law2_genoption.
 
 
@@ -376,7 +376,7 @@ Section option_sig.
   Definition δ_law1_option :=  δ_law1_genoption C hsC TC CC.
   Definition δ_law2_option :=  δ_law2_genoption C hsC TC CC.
 
-  Definition precomp_option_Signature : Signature C hsC :=
+  Definition precomp_option_Signature : Signature C hsC C hsC :=
     precomp_genoption_Signature C hsC TC CC.
 
 End option_sig.
@@ -442,7 +442,7 @@ mkpair; simpl.
 Defined.
 
 (** Signature for the Id functor *)
-Definition IdSignature : Signature C hsC :=
+Definition IdSignature : Signature C hsC C hsC :=
   tpair _ (functor_identity _) θ_functor_identity.
 
 End id_signature.

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -130,6 +130,35 @@ Definition distributive_law2 (DL : DistributiveLaw) : δ_law2 _ _ := pr2 (pr2 (p
 
 End def_of_δ.
 
+Section δ_for_id.
+
+Definition delta_functor_identity : ∑
+  δ : δ_source (functor_identity C) ⟶ δ_target (functor_identity C),
+  δ_law1 _ δ  × δ_law2 _ δ.
+Proof.
+mkpair; simpl.
++ mkpair; simpl.
+  * intro x.
+    { mkpair.
+      - intro y; simpl; apply identity.
+      - abstract (now intros y y' f; rewrite id_left, id_right).
+    }
+  * abstract (now intros y y' f; apply (nat_trans_eq hsC); intro z;
+                  simpl; rewrite id_left, id_right, id_left, functor_id, id_right; apply idpath).
++ split.
+  * apply (nat_trans_eq hsC); intro c; simpl; apply idpath.
+  * intros Ze Ze'; apply (nat_trans_eq hsC); intro c; simpl. do 3 rewrite id_left. rewrite id_right. apply pathsinv0. apply functor_id.
+Defined.
+
+Definition DL_id : DistributiveLaw.
+Proof.
+  mkpair.
+  + apply functor_identity.
+  + exact delta_functor_identity.
+Defined.
+
+End δ_for_id.
+
 (** Construct θ in a Signature in the case when the functor is
     precomposition with a functor G from a family of simpler
     distributive laws δ *)
@@ -400,7 +429,7 @@ apply pathsinv0, BinCoproductArrowUnique.
   now apply maponpaths, BinCoproductIn2Commutes.
 Qed.
 
-Definition precomp_genoption_DistributiveLaw : DistributiveLaw.
+Definition genoption_DistributiveLaw : DistributiveLaw.
 Proof.
   mkpair.
   + exact genopt.
@@ -411,7 +440,7 @@ Proof.
 Defined.
 
 Definition precomp_genoption_Signature : Signature C hsC C hsC :=
-  θ_from_δ_Signature precomp_genoption_DistributiveLaw.
+  θ_from_δ_Signature genoption_DistributiveLaw.
 
 
 End genoption_sig.
@@ -429,8 +458,8 @@ Section option_sig.
   Definition δ_law2_option :=  δ_law2_genoption TC CC.
 
 
-  Definition precomp_option_DistributiveLaw : DistributiveLaw :=
-    precomp_genoption_DistributiveLaw TC CC.
+  Definition option_DistributiveLaw : DistributiveLaw :=
+    genoption_DistributiveLaw TC CC.
   Definition precomp_option_Signature : Signature C hsC C hsC :=
     precomp_genoption_Signature TC CC.
 

--- a/UniMath/SubstitutionSystems/SignatureExamples.v
+++ b/UniMath/SubstitutionSystems/SignatureExamples.v
@@ -247,26 +247,26 @@ Qed.
 
 End δ_mul.
 
-(* Construct the δ when G = option *)
-Section option_sig.
+(** Construct the δ when G is generalized option *)
+Section genoption_sig.
 
-Variables (C : precategory) (hsC : has_homsets C) (TC : Terminal C) (CC : BinCoproducts C).
+Variables (C : precategory) (hsC : has_homsets C) (A : C) (CC : BinCoproducts C).
 
 Local Notation "'Ptd'" := (precategory_Ptd C hsC).
 
-Let opt := option_functor CC TC.
+Let genopt := constcoprod_functor1 CC A.
 
-Definition δ_option_mor (Ze : Ptd) (c : C) :  C ⟦ BinCoproductObject C (CC TC (pr1 Ze c)),
-                                                  pr1 Ze (BinCoproductObject C (CC TC c)) ⟧.
+Definition δ_genoption_mor (Ze : Ptd) (c : C) :  C ⟦ BinCoproductObject C (CC A (pr1 Ze c)),
+                                                  pr1 Ze (BinCoproductObject C (CC A c)) ⟧.
 Proof.
-apply (@BinCoproductArrow _ _ _ (CC TC (pr1 Ze c)) (pr1 Ze (BinCoproductObject C (CC TC c)))).
-- apply (BinCoproductIn1 _ (CC TC c) ;; pr2 Ze (BinCoproductObject _ (CC TC c))).
-- apply (# (pr1 Ze) (BinCoproductIn2 _ (CC TC c))).
+apply (@BinCoproductArrow _ _ _ (CC A (pr1 Ze c)) (pr1 Ze (BinCoproductObject C (CC A c)))).
+- apply (BinCoproductIn1 _ (CC A c) ;; pr2 Ze (BinCoproductObject _ (CC A c))).
+- apply (# (pr1 Ze) (BinCoproductIn2 _ (CC A c))).
 Defined.
 
-Lemma is_nat_trans_δ_option_mor (Ze : Ptd) :
-  is_nat_trans (δ_source C hsC opt Ze : functor C C) (δ_target C hsC opt Ze : functor C C)
-     (δ_option_mor Ze).
+Lemma is_nat_trans_δ_genoption_mor (Ze : Ptd) :
+  is_nat_trans (δ_source C hsC genopt Ze : functor C C) (δ_target C hsC genopt Ze : functor C C)
+     (δ_genoption_mor Ze).
 Proof.
 intros a b f; simpl.
 destruct Ze as [Z e].
@@ -293,14 +293,14 @@ apply pathsinv0, BinCoproductArrowUnique.
   now apply maponpaths, BinCoproductOfArrowsIn2.
 Qed.
 
-Lemma is_nat_trans_δ_option_mor_nat_trans : is_nat_trans (δ_source_functor_data C hsC opt)
-     (δ_target_functor_data C hsC opt)
-     (λ Ze : Ptd, δ_option_mor Ze,, is_nat_trans_δ_option_mor Ze).
+Lemma is_nat_trans_δ_genoption_mor_nat_trans : is_nat_trans (δ_source_functor_data C hsC genopt)
+     (δ_target_functor_data C hsC genopt)
+     (λ Ze : Ptd, δ_genoption_mor Ze,, is_nat_trans_δ_genoption_mor Ze).
 Proof.
 intros [Z e] [Z' e'] [α X]; simpl in *.
 apply (nat_trans_eq hsC); intro c; simpl.
 rewrite id_left, functor_id, id_right.
-unfold BinCoproduct_of_functors_mor, BinCoproduct_of_functors_ob, δ_option_mor; simpl.
+unfold BinCoproduct_of_functors_mor, BinCoproduct_of_functors_ob, δ_genoption_mor; simpl.
 rewrite precompWithBinCoproductArrow.
 apply pathsinv0, BinCoproductArrowUnique.
 - rewrite id_left, assoc.
@@ -314,29 +314,29 @@ apply pathsinv0, BinCoproductArrowUnique.
   now apply nat_trans_ax.
 Qed.
 
-Definition δ_option : δ_source C hsC opt ⟶ δ_target C hsC opt.
+Definition δ_genoption : δ_source C hsC genopt ⟶ δ_target C hsC genopt.
 Proof.
 mkpair.
 - intro Ze.
-  apply (tpair _ (δ_option_mor Ze) (is_nat_trans_δ_option_mor Ze)).
-- apply is_nat_trans_δ_option_mor_nat_trans.
+  apply (tpair _ (δ_genoption_mor Ze) (is_nat_trans_δ_genoption_mor Ze)).
+- apply is_nat_trans_δ_genoption_mor_nat_trans.
 Defined.
 
-Lemma δ_law1_option : δ_law1 C hsC opt δ_option.
+Lemma δ_law1_genoption : δ_law1 C hsC genopt δ_genoption.
 Proof.
 apply (nat_trans_eq hsC); intro c; simpl.
-unfold δ_option_mor, BinCoproduct_of_functors_ob; simpl.
+unfold δ_genoption_mor, BinCoproduct_of_functors_ob; simpl.
 rewrite id_right.
 apply pathsinv0, BinCoproduct_endo_is_identity.
 - apply BinCoproductIn1Commutes.
 - apply BinCoproductIn2Commutes.
 Qed.
 
-Lemma δ_law2_option : δ_law2 C hsC opt δ_option.
+Lemma δ_law2_genoption : δ_law2 C hsC genopt δ_genoption.
 Proof.
 intros [Z e] [Z' e'].
 apply (nat_trans_eq hsC); intro c; simpl.
-unfold δ_option_mor, BinCoproduct_of_functors_ob; simpl.
+unfold δ_genoption_mor, BinCoproduct_of_functors_ob; simpl.
 rewrite !id_left, id_right.
 apply pathsinv0, BinCoproductArrowUnique.
 - rewrite assoc.
@@ -358,8 +358,26 @@ apply pathsinv0, BinCoproductArrowUnique.
   now apply maponpaths, BinCoproductIn2Commutes.
 Qed.
 
-Definition precomp_option_Signature : Signature C hsC :=
-  θ_from_δ_Signature _ hsC opt δ_option δ_law1_option δ_law2_option.
+Definition precomp_genoption_Signature : Signature C hsC :=
+  θ_from_δ_Signature _ hsC genopt δ_genoption δ_law1_genoption δ_law2_genoption.
+
+
+End genoption_sig.
+
+
+(** trivially instantiate previous section to option functor *)
+Section option_sig.
+
+  Variables (C : precategory) (hsC : has_homsets C) (TC : Terminal C) (CC : BinCoproducts C).
+  Let opt := option_functor CC TC.
+  Definition δ_option: δ_source C hsC opt ⟶ δ_target C hsC opt :=
+    δ_genoption C hsC TC CC.
+
+  Definition δ_law1_option :=  δ_law1_genoption C hsC TC CC.
+  Definition δ_law2_option :=  δ_law2_genoption C hsC TC CC.
+
+  Definition precomp_option_Signature : Signature C hsC :=
+    precomp_genoption_Signature C hsC TC CC.
 
 End option_sig.
 

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -250,8 +250,7 @@ Section Strength_law_2_intensional.
 Definition θ_Strength2_int : UU
   := ∏ (X : EndC) (Z Z' : Ptd),
       θ (X ⊗ (Z p• Z'))  ;; #H (α_functor (U Z) (U Z') X )  =
-      (α_functor (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _
-      (* does not work as replacement:   functor_composite _ _  ⟶ _    *)
+      (α_functor (U Z) (U Z') (H X) : [C, D, hsD] ⟦ functor_compose hs hsD (functor_composite (U Z) (U Z')) (H X), functor_composite (U Z) (functor_composite (U Z') (H X)) ⟧
       ) ;;
       θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) .
 
@@ -329,7 +328,7 @@ Hypothesis θ_strength2 : θ_Strength2.
     naturality in each component here *)
 
 Lemma θ_nat_1 (X X' : EndC) (α : X --> X') (Z : Ptd)
-  : compose(C:=EndC) (# H α ∙∙ nat_trans_id (pr1 (U Z))) (θ (X' ⊗ Z)) =
+  : compose(C:=[C, D, hsD]) (# H α ∙∙ nat_trans_id (pr1 (U Z))) (θ (X' ⊗ Z)) =
         θ (X ⊗ Z);; # H (α ∙∙ nat_trans_id (pr1 (U Z))).
 Proof.
   set (t:=nat_trans_ax θ).
@@ -352,7 +351,7 @@ Lemma θ_nat_1_pointwise (X X' : EndC) (α : X --> X') (Z : Ptd) (c : C)
        pr1 (θ (X ⊗ Z)) c;; pr1 (# H (α ∙∙ nat_trans_id (pr1 Z))) c.
 Proof.
   set (t := θ_nat_1 _ _ α Z).
-  set (t' := nat_trans_eq_weq hs _ _ t c);
+  set (t' := nat_trans_eq_weq hsD _ _ t c);
   clearbody t';  simpl in t'.
   set (H':= functor_id (H X') (pr1 (pr1 Z) c));
   clearbody H'; simpl in H'.
@@ -366,7 +365,7 @@ Proof.
 Qed.
 
 Lemma θ_nat_2 (X : EndC) (Z Z' : Ptd) (f : Z --> Z')
-  : compose (C:=EndC) (identity (H X) ∙∙ pr1 f) (θ (X ⊗ Z')) =
+  : compose (C:=[C, D, hsD]) (identity (H X) ∙∙ pr1 f) (θ (X ⊗ Z')) =
        θ (X ⊗ Z);; # H (identity X ∙∙ pr1 f).
 Proof.
   set (t := nat_trans_ax θ).
@@ -386,7 +385,7 @@ Lemma θ_nat_2_pointwise (X : EndC) (Z Z' : Ptd) (f : Z --> Z') (c : C)
        pr1 (θ (X ⊗ Z)) c;; pr1 (# H (identity X ∙∙ pr1 f)) c .
 Proof.
   set (t:=θ_nat_2 X _ _ f).
-  set (t':=nat_trans_eq_weq hs _ _ t c).
+  set (t':=nat_trans_eq_weq hsD _ _ t c).
   clearbody t'; clear t.
   simpl in t'.
   rewrite id_left in t'.
@@ -402,7 +401,7 @@ End Strength_laws.
 
 Definition Signature (*C : precategory) (hs : has_homsets C*) : UU
   :=
-  ∑ H : functor [C, C, hs] [C, C, hs] ,
+  ∑ H : functor [C, C, hs] [C, D, hsD] ,
      ∑ θ : nat_trans (θ_source H) (θ_target H) , θ_Strength1_int H θ × θ_Strength2_int H θ.
 
 Coercion Signature_Functor (S : Signature) : functor _ _ := pr1 S.
@@ -417,4 +416,4 @@ End fix_a_category.
 
 
 
-Arguments theta {_ _} _ .
+Arguments theta {_ _ _ _} _ .

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -196,7 +196,7 @@ Definition θ_Strength1 : UU := ∏ X : EndC,
 
 Section Strength_law_1_intensional.
 
-  (* does not typecheck in the heterogeneous formulation *)
+(** needs the heterogeneous formulation of the monoidal operation to type-check *)
 Definition θ_Strength1_int : UU
   := ∏ X : EndC,
      θ (X ⊗ (id_Ptd C hs)) ;; # H (λ_functor _) = λ_functor _.
@@ -250,7 +250,9 @@ Section Strength_law_2_intensional.
 Definition θ_Strength2_int : UU
   := ∏ (X : EndC) (Z Z' : Ptd),
       θ (X ⊗ (Z p• Z'))  ;; #H (α_functor (U Z) (U Z') X )  =
-      (α_functor (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _ ) ;;
+      (α_functor (U Z) (U Z') (H X) : functor_compose hs hs _ _  --> _
+      (* does not work as replacement:   functor_composite _ _  ⟶ _    *)
+      ) ;;
       θ (X ⊗ Z') •• (U Z) ;; θ ((functor_compose hs hs (U Z') X) ⊗ Z) .
 
 Lemma θ_Strength2_int_implies_θ_Strength2 : θ_Strength2_int → θ_Strength2.

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -44,11 +44,15 @@ Section fix_a_category.
 Variable C : precategory.
 Variable hs : has_homsets C.
 
+(** in the original definition, this second category was the same as the first one *)
+Variable D : precategory.
+Variable hsD : has_homsets D.
+
 
 Section about_signatures.
 
-(** [H] is a rank-2 endofunctor on endofunctors *)
-Variable H : functor [C, C, hs] [C, C, hs].
+(** [H] is a rank-2 functor: a functor between functor categories *)
+Variable H : functor [C, C, hs] [C, D, hsD].
 
 (** The forgetful functor from pointed endofunctors to endofunctors *)
 Local Notation "'U'" := (functor_ptd_forget C hs).
@@ -63,13 +67,13 @@ Local Notation "'EndC'":= ([C, C, hs]) .
 
 
 (** Source is given by [(X,Z) => H(X)∙U(Z)] *)
-Definition θ_source_ob (FX : EndC XX Ptd) : [C, C, hs] := H (pr1 FX) • U (pr2 FX).
+Definition θ_source_ob (FX : EndC XX Ptd) : [C, D, hsD] := H (pr1 FX) • U (pr2 FX).
 
 Definition θ_source_mor {FX FX' : EndC XX Ptd} (αβ : FX --> FX')
   : θ_source_ob FX --> θ_source_ob FX' := horcomp (#U (pr2 αβ)) (#H (pr1 αβ)).
 
 
-Definition θ_source_functor_data : functor_data (EndC XX Ptd) EndC.
+Definition θ_source_functor_data : functor_data (EndC XX Ptd) [C, D, hsD].
 Proof.
   exists θ_source_ob.
   exact (@θ_source_mor).
@@ -80,7 +84,7 @@ Proof.
   split; simpl.
   - intro FX.
     apply nat_trans_eq.
-    + apply hs.
+    + apply hsD.
     + intro c. simpl.
       rewrite functor_id.
       rewrite id_right.
@@ -88,7 +92,7 @@ Proof.
       rewrite HH. apply idpath.
   - intros FX FX' FX'' α β.
     apply nat_trans_eq.
-    + apply hs.
+    + apply hsD.
     + destruct FX as [F X].
       destruct FX' as [F' X'].
       destruct FX'' as [F'' X''].
@@ -119,13 +123,13 @@ Definition θ_source : functor _ _ := tpair _ _ is_functor_θ_source.
 
 (** Target is given by [(X,Z) => H(X∙U(Z))] *)
 
-Definition θ_target_ob (FX : EndC XX Ptd) : EndC := H (pr1 FX • U (pr2 FX)).
+Definition θ_target_ob (FX : EndC XX Ptd) : [C, D, hsD] := H (pr1 FX • U (pr2 FX)).
 
 Definition θ_target_mor (FX FX' : EndC XX Ptd) (αβ : FX --> FX')
   : θ_target_ob FX --> θ_target_ob FX'
   := #H (pr1 αβ ∙∙ #U(pr2 αβ)).
 
-Definition θ_target_functor_data : functor_data (EndC XX Ptd) EndC.
+Definition θ_target_functor_data : functor_data (EndC XX Ptd) [C, D, hsD].
 Proof.
   exists θ_target_ob.
   exact θ_target_mor.
@@ -192,6 +196,7 @@ Definition θ_Strength1 : UU := ∏ X : EndC,
 
 Section Strength_law_1_intensional.
 
+  (* does not typecheck in the heterogeneous formulation *)
 Definition θ_Strength1_int : UU
   := ∏ X : EndC,
      θ (X ⊗ (id_Ptd C hs)) ;; # H (λ_functor _) = λ_functor _.
@@ -241,7 +246,7 @@ Definition θ_Strength2 : UU := ∏ (X : EndC) (Z Z' : Ptd) (Y : EndC)
        # H (α : functor_compose hs hs (U Z) (X • (U Z')) --> Y).
 
 Section Strength_law_2_intensional.
-
+ (* does not typecheck in the heterogeneous formulation *)
 Definition θ_Strength2_int : UU
   := ∏ (X : EndC) (Z Z' : Ptd),
       θ (X ⊗ (Z p• Z'))  ;; #H (α_functor (U Z) (U Z') X )  =

--- a/UniMath/SubstitutionSystems/SubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems.v
@@ -54,12 +54,12 @@ Local Notation "'EndC'":= ([C, C, hs]) .
 Let hsEndC : has_homsets EndC := functor_category_has_homsets C C hs.
 Let CPEndC : BinCoproducts EndC := BinCoproducts_functor_precat _ _ CP hs.
 
-Variable H : Signature C hs.
+Variable H : Signature C hs C hs.
 
 Let θ := theta H.
 
-Let θ_strength1_int := Sig_strength_law1 _ _ H.
-Let θ_strength2_int := Sig_strength_law2 _ _ H.
+Let θ_strength1_int := Sig_strength_law1 _ _ _ _ H.
+Let θ_strength2_int := Sig_strength_law2 _ _ _ _ H.
 
 Let Id_H
 : functor EndC EndC
@@ -354,7 +354,7 @@ Proof.
     clear X.
     set (A:=θ_nat_2_pointwise).
     simpl in *.
-    set (A':= A _ hs H θ (`T) Z Z').
+    set (A':= A _ hs _ hs H θ (`T) Z Z').
     simpl in A'.
     set (A2:= A' f).
     clearbody A2; clear A'; clear A.

--- a/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
+++ b/UniMath/SubstitutionSystems/SubstitutionSystems_Summary.v
@@ -101,7 +101,7 @@ Qed.
 
 Lemma fbracket_natural
      : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-       (H : Signature C hs) (T : hss CP H) (Z Z' : precategory_Ptd C hs)
+       (H : Signature C hs C hs) (T : hss CP H) (Z Z' : precategory_Ptd C hs)
        (f : precategory_Ptd C hs ⟦ Z, Z' ⟧)
        (g : precategory_Ptd C hs ⟦ Z', ptd_from_alg T ⟧),
        (`T ∘ # U f : [C,C,hs] ⟦ `T • U Z , `T • U Z' ⟧) ;; ⦃ g ⦄ = ⦃ f ;; g ⦄ .
@@ -111,7 +111,7 @@ Qed.
 
 Lemma compute_fbracket
      : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-       (H : Signature C hs) (T : hss CP H) (Z : precategory_Ptd C hs)
+       (H : Signature C hs C hs) (T : hss CP H) (Z : precategory_Ptd C hs)
        (f : precategory_Ptd C hs ⟦ Z, ptd_from_alg T ⟧),
        ⦃ f ⦄ = (`T ∘ # U f : [C,C,hs] ⟦ `T • U Z , `T • U _ ⟧) ;; ⦃ identity (ptd_from_alg T) ⦄.
 Proof.
@@ -125,7 +125,7 @@ Qed.
 
 Definition Monad_from_hss
      : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-       (H : Signature C hs), hss CP H → Monad C.
+       (H : Signature C hs C hs), hss CP H → Monad C.
 Proof.
   apply Monad_from_hss.
 Defined.
@@ -134,7 +134,7 @@ Defined.
 
 Definition hss_to_monad_functor
      : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-       (H : Signature C hs),
+       (H : Signature C hs C hs),
        functor (hss_precategory CP H) (precategory_Monad C hs).
 Proof.
   apply hss_to_monad_functor.
@@ -144,7 +144,7 @@ Defined.
 
 Lemma faithful_hss_to_monad
      : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
-       (H : Signature C hs), faithful (hss_to_monad_functor C hs CP H).
+       (H : Signature C hs C hs), faithful (hss_to_monad_functor C hs CP H).
 Proof.
   apply faithful_hss_to_monad.
 Defined.
@@ -161,7 +161,7 @@ Defined.
 Definition bracket_for_initial_algebra
  : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
      (∏ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
-       → ∏ (H : Signature C hs)
+       → ∏ (H : Signature C hs C hs)
            (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
            (Z : precategory_Ptd C hs),
            precategory_Ptd C hs ⟦ Z, ptd_from_alg (InitAlg C hs CP H IA) ⟧
@@ -175,7 +175,7 @@ Lemma bracket_Thm15_ok_η
      : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
        (KanExt : ∏ Z : precategory_Ptd C hs,
                  GlobalRightKanExtensionExists C C (U Z) C hs hs)
-       (H : Signature C hs)
+       (H : Signature C hs C hs)
        (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
        (Z : precategory_Ptd C hs)
        (f : precategory_Ptd C hs ⟦ Z, ptd_from_alg (InitAlg C hs CP H IA)⟧),
@@ -189,7 +189,7 @@ Qed.
 Lemma bracket_Thm15_ok_τ
   : ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C)
       (KanExt : ∏ Z : precategory_Ptd C hs, GlobalRightKanExtensionExists C C (U Z) C hs hs)
-      (H : Signature C hs)
+      (H : Signature C hs C hs)
       (IA : Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs)))
       (Z : precategory_Ptd C hs)
       (f : precategory_Ptd C hs ⟦ Z, ptd_from_alg (InitAlg C hs CP H IA) ⟧),
@@ -209,7 +209,7 @@ Definition Initial_HSS :
    ∏ (C : precategory) (hs : has_homsets C) (CP : BinCoproducts C),
      (∏ Z : precategory_Ptd C hs,
          GlobalRightKanExtensionExists C C (U Z) C hs hs)
-     → ∏ H : Signature C hs,
+     → ∏ H : Signature C hs C hs,
        Initial (FunctorAlg (Id_H C hs CP H) (functor_category_has_homsets C C hs))
        → Initial (hss_precategory CP H).
 Proof.
@@ -222,8 +222,8 @@ Defined.
 (** Lemma 30 *)
 
 Definition Sum_of_Signatures
-  : ∏ (C : precategory) (hs : has_homsets C),
-       BinCoproducts C → Signature C hs → Signature C hs → Signature C hs.
+  : ∏ (C : precategory) (hsC : has_homsets C)(D : precategory) (hs : has_homsets D),
+       BinCoproducts D → Signature C hsC D hs → Signature C hsC D hs → Signature C hsC D hs.
 Proof.
   apply BinSum_of_Signatures.
 Defined.
@@ -234,7 +234,7 @@ Defined.
 (** Definition 31 *)
 
 Definition App_Sig
-  : ∏ (C : precategory) (hs : has_homsets C), BinProducts C → Signature C hs.
+  : ∏ (C : precategory) (hs : has_homsets C), BinProducts C → Signature C hs C hs.
 Proof.
   apply App_Sig.
 Defined.
@@ -243,7 +243,7 @@ Defined.
 
 Definition Lam_Sig
   : ∏ (C : precategory) (hs : has_homsets C),
-    Terminal C → BinCoproducts C → BinProducts C → Signature C hs.
+    Terminal C → BinCoproducts C → BinProducts C → Signature C hs C hs.
 Proof.
   apply Lam_Sig.
 Defined.
@@ -251,7 +251,7 @@ Defined.
 (** Definition 33 *)
 
 Definition Flat_Sig
-  : ∏ (C : precategory) (hs : has_homsets C), Signature C hs.
+  : ∏ (C : precategory) (hs : has_homsets C), Signature C hs C hs.
 Proof.
   apply Flat_Sig.
 Defined.

--- a/UniMath/SubstitutionSystems/SumOfSignatures.v
+++ b/UniMath/SubstitutionSystems/SumOfSignatures.v
@@ -33,33 +33,33 @@ Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "F ⟶ G" := (nat_trans F G) (at level 39).
 Local Notation "G □ F" := (functor_composite _ _ _ F G) (at level 35).
 
-Arguments θ_source {_ _} _ .
-Arguments θ_target {_ _} _ .
-Arguments θ_Strength1 {_ _ _} _ .
-Arguments θ_Strength2 {_ _ _} _ .
-Arguments θ_Strength1_int {_ _ _} _ .
-Arguments θ_Strength2_int {_ _ _} _ .
+Arguments θ_source {_ _ _ _} _ .
+Arguments θ_target {_ _ _ _} _ .
+Arguments θ_Strength1 {_ _ _ _ _} _ .
+Arguments θ_Strength2 {_ _ _ _ _} _ .
+Arguments θ_Strength1_int {_ _ _ _ _} _ .
+Arguments θ_Strength2_int {_ _ _ _ _} _ .
 
 Section sum_of_signatures.
 
-Variables (I : UU) (HI : isdeceq I) (C : precategory) (hsC : has_homsets C).
-Variables (CC : Coproducts I C).
+Variables (I : UU) (HI : isdeceq I) (C : precategory) (hsC : has_homsets C) (D : precategory) (hsD : has_homsets D).
+Variables (CD : Coproducts I D).
 
 Section construction.
 
-Local Notation "'CCC'" := (Coproducts_functor_precat I C C CC hsC : Coproducts I [C, C, hsC]).
+Local Notation "'CCD'" := (Coproducts_functor_precat I C D CD hsD : Coproducts I [C, D, hsD]).
 
-Variables H1 : I -> functor [C, C, hsC] [C, C, hsC].
+Variables H1 : I -> functor [C, C, hsC] [C, D, hsD].
 
 Variable θ1 : ∏ i, θ_source (H1 i) ⟶ θ_target (H1 i).
 
-(** * Definition of the data of the sum of two signatures *)
+(** * Definition of the data of the sum of signatures *)
 
-Local Definition H : functor [C, C, hsC] [C, C, hsC] := coproduct_of_functors _ _ _ CCC H1.
+Local Definition H : functor [C, C, hsC] [C, D, hsD] := coproduct_of_functors _ _ _ CCD H1.
 
 Local Definition θ_ob_fun (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) (x : C) :
-   C ⟦ coproduct_of_functors_ob _ _ _ CC (λ i, H1 i X) (pr1 Z x),
-       coproduct_of_functors_ob _ _ _ CC (λ i, H1 i (functor_composite (pr1 Z) X)) x ⟧.
+   D ⟦ coproduct_of_functors_ob _ _ _ CD (λ i, H1 i X) (pr1 Z x),
+       coproduct_of_functors_ob _ _ _ CD (λ i, H1 i (functor_composite (pr1 Z) X)) x ⟧.
 Proof.
 apply CoproductOfArrows; intro i.
 exact (pr1 (θ1 i (X ⊗ Z)) x).
@@ -67,8 +67,8 @@ Defined.
 
 Local Lemma is_nat_trans_θ_ob_fun (X : [C, C, hsC]) (Z : precategory_Ptd C hsC) :
   is_nat_trans (functor_composite_data (pr1 Z)
-                 (coproduct_of_functors_data _ _ _  CC (λ i, H1 i X)))
-                 (coproduct_of_functors_data _ _ _ CC (λ i, H1 i (functor_composite (pr1 Z) X)))
+                 (coproduct_of_functors_data _ _ _  CD (λ i, H1 i X)))
+                 (coproduct_of_functors_data _ _ _ CD (λ i, H1 i (functor_composite (pr1 Z) X)))
                (θ_ob_fun X Z).
 Proof.
 intros x x' f.
@@ -84,10 +84,10 @@ intros [X Z]; exists (θ_ob_fun X Z); apply is_nat_trans_θ_ob_fun.
 Defined.
 
 Local Lemma is_nat_trans_θ_ob :
-  is_nat_trans (θ_source_functor_data C hsC H) (θ_target_functor_data C hsC H) θ_ob.
+  is_nat_trans (θ_source_functor_data C hsC D hsD H) (θ_target_functor_data C hsC D hsD H) θ_ob.
 Proof.
 intros [X Z] [X' Z'] αβ.
-apply (nat_trans_eq hsC); intro c.
+apply (nat_trans_eq hsD); intro c.
 eapply pathscomp0; [ | eapply pathsinv0, CoproductOfArrows_comp].
 eapply pathscomp0; [ apply cancel_postcomposition, CoproductOfArrows_comp |].
 eapply pathscomp0; [ apply CoproductOfArrows_comp |].
@@ -105,11 +105,11 @@ Variable S12' : ∏ i, θ_Strength2_int (θ1 i).
 Lemma SumStrength1' : θ_Strength1_int θ.
 Proof.
 intro X.
-apply (nat_trans_eq hsC); intro x; simpl.
+apply (nat_trans_eq hsD); intro x; simpl.
 eapply pathscomp0; [apply CoproductOfArrows_comp|].
 apply pathsinv0, Coproduct_endo_is_identity; intro i.
 eapply pathscomp0.
-  apply (CoproductOfArrowsIn _ _ (CC (λ i, pr1 (pr1 (H1 i) X) x))).
+  apply (CoproductOfArrowsIn _ _ (CD (λ i, pr1 (pr1 (H1 i) X) x))).
 eapply pathscomp0; [ | apply id_left].
 apply cancel_postcomposition, (nat_trans_eq_pointwise (S11' i X) x).
 Qed.
@@ -117,7 +117,7 @@ Qed.
 Lemma SumStrength2' : θ_Strength2_int θ.
 Proof.
 intros X Z Z'.
-apply (nat_trans_eq hsC); intro x; simpl; rewrite id_left.
+apply (nat_trans_eq hsD); intro x; simpl; rewrite id_left.
 eapply pathscomp0; [apply CoproductOfArrows_comp|].
 apply pathsinv0.
 eapply pathscomp0; [apply CoproductOfArrows_comp|].
@@ -128,18 +128,18 @@ Qed.
 
 End construction.
 
-Definition Sum_of_Signatures (S : I -> Signature C hsC) : Signature C hsC.
+Definition Sum_of_Signatures (S : I -> Signature C hsC D hsD) : Signature C hsC D hsD.
 Proof.
 mkpair.
 - apply H; intro i.
   apply (S i).
 - exists (θ (fun i => S i) (fun i => theta (S i))).
   split.
-  + apply SumStrength1'; intro i; apply (Sig_strength_law1 _ _ (S i)).
-  + apply SumStrength2'; intro i; apply (Sig_strength_law2 _ _ (S i)).
+  + apply SumStrength1'; intro i; apply (Sig_strength_law1 _ _ _ _ (S i)).
+  + apply SumStrength2'; intro i; apply (Sig_strength_law2 _ _ _ _ (S i)).
 Defined.
 
-Lemma is_omega_cocont_Sum_of_Signatures (S : I -> Signature C hsC)
+Lemma is_omega_cocont_Sum_of_Signatures (S : I -> Signature C hsC D hsD)
   (h : ∏ i, is_omega_cocont (S i)) (PC : Products I C) :
   is_omega_cocont (Sum_of_Signatures S).
 Proof.


### PR DESCRIPTION
in preparation for calculating the strength for multisorted binding signatures, a heterogeneous notion of signature with strength is used: the final target category can be different

the commit of February 15 (dac7742) presents the first result that will allow to construct strengths when post-composing with pr(t) or hat t