### PR TITLE
Faster type checking

### DIFF
--- a/UniMath/CategoryTheory/Monoidal/ActionBasedStrengthOnHomsInBicat.v
+++ b/UniMath/CategoryTheory/Monoidal/ActionBasedStrengthOnHomsInBicat.v
@@ -510,26 +510,6 @@ Section ActionBased_Strength_From_Signature.
   Time Qed. (* 5.172 seconds *)
   (* slow verification *)
 
-  Print actionbased_strength_pentagon_eq.
-
-  Definition test
-             (Mon_V : monoidal_precat)
-             (actn actn' : action Mon_V)
-             (F : ActionBasedStrength.A Mon_V actn ⟶ ActionBasedStrength.A' Mon_V actn')
-             (z : actionbased_strength_nat Mon_V actn actn' F)
-             (p : ∏ (X : ActionBasedStrength.A Mon_V actn)
-                    (Y HX : ActionBasedStrength.V Mon_V),
-                  ActionBasedStrength.χ' Mon_V actn' ((F X, Y), HX)
-                  · z (X, ActionBasedStrength.tensor Mon_V (Y, HX))
-                  =
-                  # (ActionBasedStrength.odot' Mon_V actn') (z (X, Y) #, id₁ HX)
-                  · z (ActionBasedStrength.odot Mon_V actn (X, Y), HX)
-                  · # F (ActionBasedStrength.χ Mon_V actn ((X, Y), HX)))
-    : actionbased_strength_pentagon_eq Mon_V actn actn' F z.
-  Proof.
-    exact p.
-  Qed.
-
   Lemma θ_for_ab_strength_law2
     : actionbased_strength_pentagon_eq
         (swapping_of_monoidal_precat (monoidal_precat_of_pointedfunctors hs))

--- a/UniMath/CategoryTheory/Monoidal/ActionBasedStrengthOnHomsInBicat.v
+++ b/UniMath/CategoryTheory/Monoidal/ActionBasedStrengthOnHomsInBicat.v
@@ -507,35 +507,98 @@ Section ActionBased_Strength_From_Signature.
     cbn.
     do 2 rewrite id_right.
     apply functor_id.
-  Qed.
+  Time Qed. (* 5.172 seconds *)
   (* slow verification *)
 
-  Lemma θ_for_ab_strength_law2 : actionbased_strength_pentagon_eq (swapping_of_monoidal_precat (monoidal_precat_of_pointedfunctors hs))
-      (ab_strength_domain_action(C:=bicat_of_cats_nouniv) (C,, hs) (D',, hsD') (forget C hs))
-      (ab_strength_target_action(C:=bicat_of_cats_nouniv) (C,, hs) (D,, hsD) (forget C hs)) H θ_for_ab_strength.
+  Print actionbased_strength_pentagon_eq.
+
+  Definition test
+             (Mon_V : monoidal_precat)
+             (actn actn' : action Mon_V)
+             (F : ActionBasedStrength.A Mon_V actn ⟶ ActionBasedStrength.A' Mon_V actn')
+             (z : actionbased_strength_nat Mon_V actn actn' F)
+             (p : ∏ (X : ActionBasedStrength.A Mon_V actn)
+                    (Y HX : ActionBasedStrength.V Mon_V),
+                  ActionBasedStrength.χ' Mon_V actn' ((F X, Y), HX)
+                  · z (X, ActionBasedStrength.tensor Mon_V (Y, HX))
+                  =
+                  # (ActionBasedStrength.odot' Mon_V actn') (z (X, Y) #, id₁ HX)
+                  · z (ActionBasedStrength.odot Mon_V actn (X, Y), HX)
+                  · # F (ActionBasedStrength.χ Mon_V actn ((X, Y), HX)))
+    : actionbased_strength_pentagon_eq Mon_V actn actn' F z.
   Proof.
-    red. intros X Z Z'.
-    (* unfold ActionBasedStrength.χ', θ_for_ab_strength, ActionBasedStrength.odot', ActionBasedStrength.χ. *)
-    simpl.
+    exact p.
+  Qed.
+
+  Lemma θ_for_ab_strength_law2
+    : actionbased_strength_pentagon_eq
+        (swapping_of_monoidal_precat (monoidal_precat_of_pointedfunctors hs))
+        (ab_strength_domain_action
+           (C:=bicat_of_cats_nouniv)
+           (C ,, hs) (D' ,, hsD')
+           (forget C hs))
+        (ab_strength_target_action
+           (C:=bicat_of_cats_nouniv)
+           (C ,, hs) (D ,, hsD)
+           (forget C hs))
+        H
+        θ_for_ab_strength.
+  Proof.
+    intros X Z' Z.
+    cbn.
     apply nat_trans_eq; try (exact hsD).
     intro c.
     simpl.
-    assert (HypX := pr1 (θ_Strength2_int_nicer _ _ _ _ _ _ _ _) (Sig_strength_law2 _ _ _ _ _ _ sig) X Z' Z).
+    assert (HypX := pr1 (θ_Strength2_int_nicer _ _ _ _ _ _ _ _)
+                        (Sig_strength_law2 _ _ _ _ _ _ sig) X Z Z').
     fold θ'' in HypX.
     fold H in HypX.
     assert (Heqc := nat_trans_eq_weq hsD _ _ HypX c).
     clear HypX.
     cbn in Heqc.
     etrans.
-    { rewrite id_left. rewrite id_right.
-      rewrite (functor_id (H X)). apply id_left. }
-    rewrite id_left in Heqc.
-    rewrite functor_id.
-    rewrite (functor_id (H X)).
-    rewrite id_left.
+    {
+      apply maponpaths_2.
+      etrans.
+      {
+        apply maponpaths.
+        apply id_right.
+      }
+      apply id_left.
+    }
     etrans.
-    { exact Heqc. }
+    {
+      etrans.
+      {
+        apply maponpaths_2.
+        apply functor_id.
+      }
+      apply id_left.
+    }
+    refine (!_).
+    etrans.
+    {
+      do 2 apply maponpaths_2.
+      etrans.
+      {
+        apply maponpaths_2.
+        etrans.
+        {
+          apply maponpaths.
+          apply functor_id.
+        }
+        apply functor_id.
+      }
+      apply id_left.
+    }
+    refine (!_).
+    refine (Heqc @ _).
     clear Heqc.
+    etrans.
+    {
+      do 2 apply maponpaths_2.
+      apply id_left.
+    }
     apply maponpaths.
     apply nat_trans_eq_pointwise.
     clear c.
@@ -547,7 +610,7 @@ Section ActionBased_Strength_From_Signature.
     rewrite id_left.
     apply pathsinv0.
     apply functor_id.
-  Qed.
+  Time Qed. (* *)
   (* potentially non-terminating verification on certain Coq installations *)
 
   Definition ab_strength_from_signature : ab_strength_for_functors_and_pointed_functors C hs D hsD D' hsD' H.

--- a/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
+++ b/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
@@ -107,7 +107,6 @@ Proof.
     + exact (identity_is_z_iso _ ).
     + apply (is_z_iso_inv_from_z_iso _ _ (make_z_iso _ _ ϵ_U_is_z_iso)).
 Defined.
-
 Definition lifted_action_convertor_nat_trans:
   odot_x_odot_y_functor _ lifted_odot ⟹ odot_x_otimes_y_functor _ lifted_odot.
 Proof.
@@ -198,7 +197,7 @@ Proof.
        unfold functor_fix_snd_arg_ob in TYPE. *)
     apply pathsinv0.
     apply (pr12(pr222 actA)).
-Qed.
+Defined.
 
 Lemma lifted_action_plaw : action_pentagon_eq (A := C) Mon_V
                              lifted_odot lifted_action_convertor.
@@ -292,7 +291,7 @@ Proof.
   change (# odotA (# odotA (id (a, U x)) #, μ (y, z)) = # odotA (id (odotA (a, U x)) #, μ (y, z))).
   rewrite functor_id.
   apply idpath.
-Qed.
+Defined.
 
 Definition lifted_action: action Mon_V.
 Proof.
@@ -308,7 +307,6 @@ Defined.
 End Action_Lifting_Through_Strong_Monoidal_Functor.
 
 End A.
-
 (*
 Section Strong_Monoidal_Functor_Action_Reloaded.
 

--- a/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
+++ b/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
@@ -88,11 +88,12 @@ Proof.
   use tpair.
   - intro a.
     apply (pr1 aux a).
-  - cbn; red.
-    intros a a' f.
-    cbn.
-    rewrite functor_id.
-    exact (pr2 aux a a' f).
+  - abstract
+      (cbn; red ;
+       intros a a' f ;
+       cbn ;
+       rewrite functor_id ;
+       exact (pr2 aux a a' f)).
 Defined.
 
 Definition lifted_action_right_unitor: action_right_unitor Mon_V lifted_odot.
@@ -197,7 +198,7 @@ Proof.
        unfold functor_fix_snd_arg_ob in TYPE. *)
     apply pathsinv0.
     apply (pr12(pr222 actA)).
-Defined.
+Qed.
 
 Lemma lifted_action_plaw : action_pentagon_eq (A := C) Mon_V
                              lifted_odot lifted_action_convertor.
@@ -291,7 +292,7 @@ Proof.
   change (# odotA (# odotA (id (a, U x)) #, μ (y, z)) = # odotA (id (odotA (a, U x)) #, μ (y, z))).
   rewrite functor_id.
   apply idpath.
-Defined.
+Qed.
 
 Definition lifted_action: action Mon_V.
 Proof.
@@ -308,6 +309,7 @@ End Action_Lifting_Through_Strong_Monoidal_Functor.
 
 End A.
 
+(*
 Section Strong_Monoidal_Functor_Action_Reloaded.
 
   Context {Mon_V Mon_A : monoidal_precat}.
@@ -316,10 +318,12 @@ Section Strong_Monoidal_Functor_Action_Reloaded.
   Definition U_action_alt : action Mon_V := lifted_action Mon_V U (action_on_itself Mon_A).
 
 (* the two actions are even convertible - thanks to definedness of the proofs of the equations *)
+  (*
   Lemma U_action_alt_ok: U_action_alt = U_action _ U.
   Proof.
-    apply idpath.
+    do 2 (use total2_paths_f ; [ apply idpath | ] ; cbn).
   Qed.
+   *)
 
 (* the following lemmas work even when the equational proofs are opaque *)
   Lemma U_action_alt_ok1: pr1 U_action_alt = pr1(U_action _ U).
@@ -343,3 +347,4 @@ Section Strong_Monoidal_Functor_Action_Reloaded.
   Qed.
 
 End Strong_Monoidal_Functor_Action_Reloaded.
+ *)

--- a/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
+++ b/UniMath/CategoryTheory/Monoidal/ConstructionOfActions.v
@@ -88,12 +88,11 @@ Proof.
   use tpair.
   - intro a.
     apply (pr1 aux a).
-  - abstract
-      (cbn; red ;
-       intros a a' f ;
-       cbn ;
-       rewrite functor_id ;
-       exact (pr2 aux a a' f)).
+  - cbn; red.
+    intros a a' f.
+    cbn.
+    rewrite functor_id.
+    exact (pr2 aux a a' f).
 Defined.
 
 Definition lifted_action_right_unitor: action_right_unitor Mon_V lifted_odot.
@@ -307,7 +306,7 @@ Defined.
 End Action_Lifting_Through_Strong_Monoidal_Functor.
 
 End A.
-(*
+
 Section Strong_Monoidal_Functor_Action_Reloaded.
 
   Context {Mon_V Mon_A : monoidal_precat}.
@@ -316,12 +315,10 @@ Section Strong_Monoidal_Functor_Action_Reloaded.
   Definition U_action_alt : action Mon_V := lifted_action Mon_V U (action_on_itself Mon_A).
 
 (* the two actions are even convertible - thanks to definedness of the proofs of the equations *)
-  (*
   Lemma U_action_alt_ok: U_action_alt = U_action _ U.
   Proof.
-    do 2 (use total2_paths_f ; [ apply idpath | ] ; cbn).
+    apply idpath.
   Qed.
-   *)
 
 (* the following lemmas work even when the equational proofs are opaque *)
   Lemma U_action_alt_ok1: pr1 U_action_alt = pr1(U_action _ U).
@@ -345,4 +342,3 @@ Section Strong_Monoidal_Functor_Action_Reloaded.
   Qed.
 
 End Strong_Monoidal_Functor_Action_Reloaded.
- *)

--- a/UniMath/CategoryTheory/Monoidal/PointedFunctorsMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/PointedFunctorsMonoidal.v
@@ -14,8 +14,7 @@ Contents :
 ************************************************************)
 
 Require Import UniMath.Foundations.PartD.
-
-Require Import UniMath.MoreFoundations.Tactics.
+Require Import UniMath.MoreFoundations.All.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
@@ -41,45 +40,42 @@ Section PointedFunctors_as_monoidal_category.
 
   Local Notation "'Ptd'" := (precategory_Ptd C hs).
 
-  Definition tensor_pointedfunctors:
-    precategory_Ptd C hs ⊠ precategory_Ptd C hs ⟶ precategory_Ptd C hs.
-Proof.
-  use make_functor.
-  - use make_functor_data.
-    + intro PF1PF2.
-      induction PF1PF2 as [PF1 PF2].
-      exact (ptd_composite C hs PF1 PF2).
-    + intros PF1PF2 PF1'PF2' α1α2.
+  Definition tensor_pointedfunctor_data
+    : functor_data (Ptd ⊠ Ptd) Ptd.
+  Proof.
+    use make_functor_data.
+    - intros PF1PF2.
+      exact (ptd_composite C hs (pr1 PF1PF2) (pr2 PF1PF2)).
+    - intros PF1PF2 PF'PF2' α1α2.
       induction α1α2 as [α1 α2].
       cbn in *.
-      exists (horcomp α1 α2).
-      red; intro c.
-      cbn.
-      rewrite assoc.
-      etrans.
-      { apply cancel_postcomposition.
-        rewrite <- assoc.
-        rewrite nat_trans_ax.
-        rewrite assoc.
-        apply cancel_postcomposition.
-        apply ptd_mor_commutes.
-      }
-      rewrite <- assoc.
-      rewrite <- functor_comp.
-      etrans.
-      { do 2 apply maponpaths.
-        apply ptd_mor_commutes. }
-      apply idpath.
-  - split; red; cbn.
-    + intro PF1PF2.
+      simple refine (horcomp α1 α2 ,, _).
+      abstract
+        (intro c ; cbn ;
+         rewrite assoc ;
+         refine (maponpaths (λ z, z · _) _ @ _) ;
+           [ rewrite <- assoc ;
+             rewrite nat_trans_ax ;
+             rewrite assoc ;
+             apply cancel_postcomposition ;
+             apply ptd_mor_commutes
+           | rewrite <- assoc ;
+             rewrite <- functor_comp ;
+             do 2 apply maponpaths ;
+             apply ptd_mor_commutes ]).
+  Defined.
+
+  Definition tensor_pointedfunctor_is_functor
+    : is_functor tensor_pointedfunctor_data.
+  Proof.
+    split.
+    - intro PF1PF2 ; cbn.
       (* UniMath.MoreFoundations.Tactics.show_id_type. *)
       apply eq_ptd_mor; try assumption.
       cbn.
       apply nat_trans_eq; try assumption; intro c.
-      etrans.
-      { apply horcomp_id_left. }
-      apply idpath.
-    + intros PF1PF2 PF1'PF2' PF1''PF2'' α1α2 α1'α2'.
+      apply horcomp_id_left.
+    - intros PF1PF2 PF1'PF2' PF1''PF2'' α1α2 α1'α2'.
       apply eq_ptd_mor; try assumption.
       cbn.
       apply nat_trans_eq; try assumption; intro c.
@@ -91,224 +87,260 @@ Proof.
       apply cancel_postcomposition.
       apply pathsinv0.
       apply nat_trans_ax.
-Defined.
+  Qed.
 
-(** a preparation for the lemma afterwards *)
-Lemma ptd_mor_z_iso_from_underlying_mor {F G : Ptd} (α : ptd_mor C F G):
-  is_nat_z_iso(pr1 α) -> is_z_isomorphism(C:=Ptd) α.
-Proof.
-  intro Hyp.
-  use tpair.
-  - use tpair.
-    apply nat_z_iso_to_trans_inv.
-    + exact (_ ,, Hyp).
-    + cbn. red; intro c.
-      cbn.
-      apply pathsinv0.
-      apply (z_iso_inv_on_left _ _ _ _ (make_z_iso _ _ (Hyp c))).
-      cbn.
-      apply pathsinv0.
-      apply ptd_mor_commutes.
-  - red; split; apply eq_ptd_mor; try assumption; apply nat_trans_eq;
-      try assumption; intro c; cbn.
-    + apply (z_iso_inv_after_z_iso (make_z_iso _ _ (Hyp c))).
-    + apply (z_iso_after_z_iso_inv (make_z_iso _ _ (Hyp c))).
-Defined.
+  Definition tensor_pointedfunctors
+    : precategory_Ptd C hs ⊠ precategory_Ptd C hs
+      ⟶
+      precategory_Ptd C hs.
+  Proof.
+    use make_functor.
+    - exact tensor_pointedfunctor_data.
+    - exact tensor_pointedfunctor_is_functor.
+  Defined.
 
-Definition left_unitor_of_pointedfunctors:
-  left_unitor tensor_pointedfunctors (id_Ptd C hs).
-Proof.
-  use make_nat_z_iso.
-  + use make_nat_trans.
-    * intro PF.
-      exists (λ_functor (pr1 PF)).
-      red; intro c.
-      cbn.
-      rewrite functor_id.
-      rewrite id_right.
-      apply id_right.
-    * intros PF PF' α.
-      apply eq_ptd_mor; try assumption.
-      apply nat_trans_eq; try assumption.
-      intro c. cbn.
-      rewrite functor_id.
-      rewrite id_left.
-      do 2 rewrite id_right.
-      apply idpath.
-  + red. intro PF. cbn.
-    apply ptd_mor_z_iso_from_underlying_mor.
-    intro c.
-    cbn.
-    apply identity_is_z_iso.
-Defined.
+  (** a preparation for the lemma afterwards *)
+  Lemma ptd_mor_z_iso_from_underlying_mor {F G : Ptd} (α : ptd_mor C F G):
+    is_nat_z_iso(pr1 α) -> is_z_isomorphism(C:=Ptd) α.
+  Proof.
+    intro Hyp.
+    use tpair.
+    - use tpair.
+      apply nat_z_iso_to_trans_inv.
+      + exact (_ ,, Hyp).
+      + abstract
+          (cbn ; red; intro c ;
+           cbn ;
+           apply pathsinv0 ;
+           apply (z_iso_inv_on_left _ _ _ _ (make_z_iso _ _ (Hyp c))) ;
+           cbn ;
+           apply pathsinv0 ;
+           apply ptd_mor_commutes).
+    - abstract
+        (red; split; apply eq_ptd_mor; try assumption; apply nat_trans_eq;
+         try assumption; intro c; cbn ;
+         [ apply (z_iso_inv_after_z_iso (make_z_iso _ _ (Hyp c)))
+          | apply (z_iso_after_z_iso_inv (make_z_iso _ _ (Hyp c))) ]).
+  Defined.
 
-Definition right_unitor_of_pointedfunctors:
-  right_unitor tensor_pointedfunctors (id_Ptd C hs).
-Proof.
-  use make_nat_z_iso.
-  + use make_nat_trans.
-    * intro PF.
-      exists (ρ_functor (pr1 PF)).
-      red; intro c.
-      cbn.
-      rewrite id_right.
-      apply id_left.
-    * intros PF PF' α.
-      apply eq_ptd_mor; try assumption.
-      apply nat_trans_eq; try assumption.
-      intro c. cbn.
-      do 2 rewrite id_left.
-      apply id_right.
-  + red. intro PF. cbn.
-    apply ptd_mor_z_iso_from_underlying_mor.
-    intro c.
-    cbn.
-    apply identity_is_z_iso.
-Defined.
-
-Definition associator_of_pointedfunctors: associator tensor_pointedfunctors.
-Proof.
-  use make_nat_z_iso.
-  + use make_nat_trans.
-    * intro PFtriple.
-      induction PFtriple as [[PF1 PF2] PF3].
-      exists (α_functor (pr1 PF1) (pr1 PF2) (pr1 PF3)).
-      red; intro c.
-      cbn.
-      rewrite id_right.
-      rewrite functor_comp.
-      apply assoc.
-    * intros PFtriple PFtriple' αtriple.
-      apply eq_ptd_mor; try assumption.
-      apply nat_trans_eq; try assumption.
-      intro c. cbn.
-      rewrite id_right.
-      rewrite id_left.
-      rewrite functor_comp.
-      rewrite <- assoc.
-      apply idpath.
-  + red. intro PFtriple. cbn.
-    apply ptd_mor_z_iso_from_underlying_mor.
-    intro c.
-    cbn.
-    apply identity_is_z_iso.
-Defined.
-
-Lemma triangle_eq_of_pointedfunctors:
-  triangle_eq tensor_pointedfunctors (id_Ptd C hs)
-              left_unitor_of_pointedfunctors
-              right_unitor_of_pointedfunctors
-              associator_of_pointedfunctors.
-Proof.
-  intros PF1 PF2.
-  apply eq_ptd_mor; try assumption.
-  (* UniMath.MoreFoundations.Tactics.show_id_type. *)
-  apply nat_trans_eq; try assumption.
-  intro c.
-  cbn.
-  do 3 rewrite id_left.
-  apply idpath.
-Qed.
-
-Lemma pentagon_eq_of_pointedfunctors:
-  pentagon_eq tensor_pointedfunctors associator_of_pointedfunctors.
-Proof.
-  intros PF1 PF2 PF3 PF4.
-  apply eq_ptd_mor; try assumption.
-  apply nat_trans_eq; try assumption.
-  intro c.
-  cbn.
-  do 4 rewrite functor_id.
-  do 5 rewrite id_left.
-  apply idpath.
-Qed.
-
-Definition monoidal_precat_of_pointedfunctors: monoidal_precat.
-Proof.
-  use mk_monoidal_precat.
-  - exact Ptd.
-  - apply tensor_pointedfunctors.
-  - apply id_Ptd.
-  - exact left_unitor_of_pointedfunctors.
-  - exact right_unitor_of_pointedfunctors.
-  - exact associator_of_pointedfunctors.
-  - exact triangle_eq_of_pointedfunctors.
-  - exact pentagon_eq_of_pointedfunctors.
-Defined.
-
-Definition forgetful_functor_from_ptd_as_strong_monoidal_functor: strong_monoidal_functor monoidal_precat_of_pointedfunctors (monoidal_precat_of_endofunctors hs).
-Proof.
-  use tpair.
-  - apply (mk_lax_monoidal_functor monoidal_precat_of_pointedfunctors (monoidal_precat_of_endofunctors hs) (functor_ptd_forget C hs) (nat_trans_id _) (nat_trans_id _)).
-    + intros PF1 PF2 PF3.
-      apply nat_trans_eq; try assumption.
+  Definition left_unitor_of_pointedfunctors:
+    left_unitor tensor_pointedfunctors (id_Ptd C hs).
+  Proof.
+    use make_nat_z_iso.
+    + use make_nat_trans.
+      * intro PF.
+        exists (λ_functor (pr1 PF)).
+        abstract
+          (red; intro c ;
+           cbn ;
+           rewrite functor_id ;
+           rewrite id_right ;
+           apply id_right).
+      * abstract
+          (intros PF PF' α ;
+           apply eq_ptd_mor; try assumption ;
+           apply nat_trans_eq; try assumption ;
+           intro c ; cbn ;
+           rewrite functor_id ;
+           rewrite id_left ;
+           do 2 rewrite id_right ;
+           apply idpath).
+    + red. intro PF. cbn.
+      apply ptd_mor_z_iso_from_underlying_mor.
       intro c.
       cbn.
-      do 3 rewrite functor_id.
-      rewrite assoc.
-      apply idpath.
-    + intro PF.
-      split; apply nat_trans_eq; try assumption; intro c; cbn.
-      * rewrite functor_id.
-        do 3 rewrite id_right.
-        apply idpath.
-      * do 3 rewrite id_right.
-        apply idpath.
-  - split; [apply (nat_trafo_z_iso_if_pointwise_z_iso C C hs);
-                       apply is_nat_z_iso_nat_trans_id
-                      | apply (is_nat_z_iso_nat_trans_id ((functor_composite
-          (PrecategoryBinProduct.pair_functor (functor_ptd_forget C hs) (functor_ptd_forget C hs))
-          (functorial_composition C C C hs hs))))].
-Defined.
+      apply identity_is_z_iso.
+  Defined.
 
-(** formally, we also need this functor with a different target category *)
-Definition functor_ptd_forget_alt : precategory_Ptd C hs ⟶ precategory_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,, hs).
-Proof.
-  use make_functor.
-  - exists (λ a, pr1 a).
-    exact (λ a b f, pr1 f).
-  - split; intros; red; intros; apply idpath.
-Defined.
-
-Local Definition aux : monoidal_functor_map monoidal_precat_of_pointedfunctors
-   (monoidal_precat_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,, hs)) functor_ptd_forget_alt.
-Proof.
-  red.
-  use make_nat_trans.
-  - intro x. cbn. apply nat_trans_id.
-  - red. intros. apply nat_trans_eq; try assumption.
-    intro y. cbn. rewrite id_left. rewrite id_right. apply nat_trans_ax.
-Defined.
-
-Definition forgetful_functor_from_ptd_as_strong_monoidal_functor_alt: strong_monoidal_functor monoidal_precat_of_pointedfunctors (monoidal_precat_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,,hs)).
-Proof.
-  use tpair.
-  - apply (mk_lax_monoidal_functor monoidal_precat_of_pointedfunctors (monoidal_precat_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,, hs)) functor_ptd_forget_alt (nat_trans_id _) aux).
-    + intros PF1 PF2 PF3.
-      apply nat_trans_eq; try assumption.
+  Definition right_unitor_of_pointedfunctors:
+    right_unitor tensor_pointedfunctors (id_Ptd C hs).
+  Proof.
+    use make_nat_z_iso.
+    + use make_nat_trans.
+      * intro PF.
+        exists (ρ_functor (pr1 PF)).
+        abstract
+          (red; intro c ;
+           cbn ;
+           rewrite id_right ;
+           apply id_left).
+      * abstract
+          (intros PF PF' α ;
+           apply eq_ptd_mor; try assumption ;
+           apply nat_trans_eq; try assumption ;
+           intro c ; cbn ;
+           do 2 rewrite id_left ;
+           apply id_right).
+    + red. intro PF. cbn.
+      apply ptd_mor_z_iso_from_underlying_mor.
       intro c.
       cbn.
-      do 2 rewrite functor_id.
-      repeat rewrite id_right.
-      apply functor_id.
-    + intro PF.
-      split; apply nat_trans_eq; try assumption; intro c; cbn.
-      * do 3 rewrite id_right.
-        apply pathsinv0.
-        apply functor_id.
-      * do 3 rewrite id_right.
-        apply idpath.
-  - split.
-    + apply (nat_trafo_z_iso_if_pointwise_z_iso C C hs);
-        apply is_nat_z_iso_nat_trans_id.
-    + red. intro c.
-      exists (nat_trans_id _).
-      split; cbn.
-      * apply nat_trans_eq; try assumption; intro c'; cbn.
-        apply id_left.
-      * apply nat_trans_eq; try assumption; intro c'; cbn.
-        apply id_left.
-Defined.
-(* very slow *)
+      apply identity_is_z_iso.
+  Defined.
 
+  Definition associator_of_pointedfunctors: associator tensor_pointedfunctors.
+  Proof.
+    use make_nat_z_iso.
+    + use make_nat_trans.
+      * intro PFtriple.
+        induction PFtriple as [[PF1 PF2] PF3].
+        exists (α_functor (pr1 PF1) (pr1 PF2) (pr1 PF3)).
+        abstract
+          (red; intro c ;
+           cbn ;
+           rewrite id_right ;
+           rewrite functor_comp ;
+           apply assoc).
+      * abstract
+          (intros PFtriple PFtriple' αtriple ;
+           apply eq_ptd_mor; try assumption ;
+           apply nat_trans_eq; try assumption ;
+           intro c ; cbn ;
+           rewrite id_right ;
+           rewrite id_left ;
+           rewrite functor_comp ;
+           rewrite <- assoc ;
+           apply idpath).
+    + red. intro PFtriple. cbn.
+      apply ptd_mor_z_iso_from_underlying_mor.
+      intro c.
+      cbn.
+      apply identity_is_z_iso.
+  Defined.
+
+  Lemma triangle_eq_of_pointedfunctors:
+    triangle_eq tensor_pointedfunctors (id_Ptd C hs)
+                left_unitor_of_pointedfunctors
+                right_unitor_of_pointedfunctors
+                associator_of_pointedfunctors.
+  Proof.
+    intros PF1 PF2.
+    apply eq_ptd_mor; try assumption.
+    (* UniMath.MoreFoundations.Tactics.show_id_type. *)
+    apply nat_trans_eq; try assumption.
+    intro c.
+    cbn.
+    do 3 rewrite id_left.
+    apply idpath.
+  Qed.
+
+  Lemma pentagon_eq_of_pointedfunctors:
+    pentagon_eq tensor_pointedfunctors associator_of_pointedfunctors.
+  Proof.
+    intros PF1 PF2 PF3 PF4.
+    apply eq_ptd_mor; try assumption.
+    apply nat_trans_eq; try assumption.
+    intro c.
+    cbn.
+    do 4 rewrite functor_id.
+    do 5 rewrite id_left.
+    apply idpath.
+  Qed.
+
+  Definition monoidal_precat_of_pointedfunctors: monoidal_precat.
+  Proof.
+    use mk_monoidal_precat.
+    - exact Ptd.
+    - apply tensor_pointedfunctors.
+    - apply id_Ptd.
+    - exact left_unitor_of_pointedfunctors.
+    - exact right_unitor_of_pointedfunctors.
+    - exact associator_of_pointedfunctors.
+    - exact triangle_eq_of_pointedfunctors.
+    - exact pentagon_eq_of_pointedfunctors.
+  Defined.
+
+  Definition forgetful_functor_from_ptd_as_strong_monoidal_functor
+    : strong_monoidal_functor
+        monoidal_precat_of_pointedfunctors
+        (monoidal_precat_of_endofunctors hs).
+  Proof.
+    use tpair.
+    - apply (mk_lax_monoidal_functor
+               monoidal_precat_of_pointedfunctors
+               (monoidal_precat_of_endofunctors hs)
+               (functor_ptd_forget C hs)
+               (nat_trans_id _)
+               (nat_trans_id _)).
+      + abstract
+          (intros PF1 PF2 PF3 ;
+           apply nat_trans_eq; try assumption ;
+           intro c ;
+           cbn ;
+           do 3 rewrite functor_id ;
+           rewrite assoc ;
+           apply idpath).
+      + abstract
+          (intro PF ;
+           split; apply nat_trans_eq; try assumption; intro c; cbn ;
+           [ rewrite functor_id ;
+             do 3 rewrite id_right ;
+             apply idpath
+           | do 3 rewrite id_right ;
+             apply idpath]).
+    - split;
+        [ apply (nat_trafo_z_iso_if_pointwise_z_iso C C hs);
+          apply is_nat_z_iso_nat_trans_id
+        | apply (is_nat_z_iso_nat_trans_id
+                   ((functor_composite
+                       (PrecategoryBinProduct.pair_functor
+                          (functor_ptd_forget C hs)
+                          (functor_ptd_forget C hs))
+                       (functorial_composition C C C hs hs))))].
+  Defined.
+
+  (** formally, we also need this functor with a different target category *)
+  Definition functor_ptd_forget_alt
+    : precategory_Ptd C hs
+      ⟶
+      precategory_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,, hs).
+  Proof.
+    use make_functor.
+    - exists (λ a, pr1 a).
+      exact (λ a b f, pr1 f).
+    - abstract (split; intros; red; intros; apply idpath).
+  Defined.
+
+  Local Definition aux : monoidal_functor_map monoidal_precat_of_pointedfunctors
+                                              (monoidal_precat_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,, hs)) functor_ptd_forget_alt.
+  Proof.
+    red.
+    use make_nat_trans.
+    - intro x. cbn. apply nat_trans_id.
+    - abstract
+        (red ; intros ; apply nat_trans_eq; try assumption ;
+         intro y ; cbn ; rewrite id_left ; rewrite id_right ; apply nat_trans_ax).
+  Defined.
+
+  Definition forgetful_functor_from_ptd_as_strong_monoidal_functor_alt: strong_monoidal_functor monoidal_precat_of_pointedfunctors (monoidal_precat_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,,hs)).
+  Proof.
+    use tpair.
+    - apply (mk_lax_monoidal_functor monoidal_precat_of_pointedfunctors (monoidal_precat_from_prebicat_and_ob(C:=pr1 bicat_of_cats_nouniv) (C,, hs)) functor_ptd_forget_alt (nat_trans_id _) aux).
+      + abstract
+          (intros PF1 PF2 PF3 ;
+           apply nat_trans_eq; try assumption ;
+           intro c ;
+           cbn ;
+           do 2 rewrite functor_id ;
+           repeat rewrite id_right ;
+           apply functor_id).
+      + abstract
+          (intro PF ;
+           split; apply nat_trans_eq; try assumption; intro c; cbn ;
+             [ do 3 rewrite id_right ;
+               apply pathsinv0 ;
+               apply functor_id
+             | do 3 rewrite id_right ;
+               apply idpath]).
+    - split ;
+        [ apply (nat_trafo_z_iso_if_pointwise_z_iso C C hs);
+          apply is_nat_z_iso_nat_trans_id
+        | red ; intro c ;
+          exists (nat_trans_id _) ;
+          split; cbn ;
+          [ apply nat_trans_eq; try assumption; intro c'; cbn ;
+            apply id_left
+          | apply nat_trans_eq; try assumption; intro c'; cbn ;
+            apply id_left ]].
+  Defined.
 End PointedFunctors_as_monoidal_category.


### PR DESCRIPTION
On my machine, `θ_for_ab_strength_law2` type checks within 2 minutes now (the version before didn't finish within 5~7 minutes). The main change is that in `PointedFunctorsMonoidal.v`, I made as much opaque as possible.