### PR TITLE
Fix some files for bicategories

### DIFF
--- a/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/CwF.v
@@ -259,23 +259,20 @@ Section CwFRepresentation.
         cbn.
         unfold from_Pullback_to_Pullback.
         cbn in *.
-        admit. (*
-        match goal with |[|- (_  ( _ ?PP _ _ _  _ ) )  _ _ · _ = _ ] =>
-                         set (P:=PP) end.
-        match goal with |[|- ( _ (PullbackArrow _ ?PP ?E2 ?E3 _ )) _ _ · _ = _ ]
-                         => set (E1 := PP);
-                              set (e1 := E1);
-                              set (e2 := E2);
-                              set (e3 := E3) end.
-        match goal with |[|- ( _ (PullbackArrow _ _ _ _ ?E4 )) _ _ · _ = _ ]
-                         => set (e4 := E4) end.
-        assert (XR := PullbackArrow_PullbackPr1 P e1 e2 e3 e4).
-        assert (XR':= nat_trans_eq_pointwise XR ΓA').
+        pose (XR' := nat_trans_eq_pointwise
+                       (PullbackArrow_PullbackPr1
+                          (make_Pullback _ isP)
+                          (yoneda_objects C ΓA')
+                          (yoneda_morphisms C ΓA' Γ π')
+                          (yoneda_map_2 C ΓA' Tm te')
+                          (PullbackSqrCommutes
+                             (make_Pullback _ isP')))
+                       ΓA').
         cbn in XR'.
         assert (XR'':= toforallpaths _ _  _ XR').
         cbn in XR''.
         etrans. apply XR''.
-        apply id_left. *)
+        apply id_left.
       + unfold TT; clear TT.
         match goal with |[|- transportf ?r  _ _ = _ ] => set (P:=r) end.
         match goal with |[|- transportf _ (_ _ _ (_ _ ?ii)) _ = _ ] => set (i:=ii) end.
@@ -295,20 +292,15 @@ Section CwFRepresentation.
         etrans. apply maponpaths_2. apply XX.
         clear XX.
         etrans. apply maponpaths_2. unfold from_Pullback_to_Pullback. apply idpath.
-        admit. (*
-        match goal with |[|- ( _ ?PP _ _ _  _ ) · _ = _ ] =>
-                         set (PT:=PP) end.
-        match goal with |[|- PullbackArrow _ ?PP ?E2 ?E3 _ · _ = _ ]
-                         => set (E1 := PP);
-                              set (e1 := E1);
-                              set (e2 := E2);
-                              set (e3 := E3) end.
-        match goal with |[|- PullbackArrow _ _ _ _ ?E4 · _ = _ ]
-                         => set (e4 := E4) end.
-        apply (PullbackArrow_PullbackPr2 PT e1 e2 e3 e4).
-
+        pose (XR' := PullbackArrow_PullbackPr2
+                       (make_Pullback _ isP)
+                       (yoneda_objects C ΓA')
+                       (yoneda_morphisms C ΓA' Γ π')
+                       (yoneda_map_2 C ΓA' Tm te')
+                       (PullbackSqrCommutes
+                          (make_Pullback _ isP'))).
+        apply XR'.
   Qed.
-*) Admitted.
 
   Definition cwf_representation : UU
     := ∏ Γ (A : Ty Γ : hSet), cwf_fiber_representation A.

--- a/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
+++ b/UniMath/Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v
@@ -391,63 +391,47 @@ Proof.
   simple refine (_ ,, _).
   - exact (pr111 Hαα x xx).
   - split.
-    + unfold transportb.
-      admit.
-      (*etrans ; [ apply maponpaths ; apply (maponpaths (λ z, pr11 z x xx) (pr22 Hαα)) |] .
-
-
-      abstract
-        (unfold transportb ;   TODO
-         (* etrans ; [ apply mor_disp_transportf_postwhisker | ] ; *)
-         etrans ; [ apply maponpaths ; apply (maponpaths (λ z, pr11 z x xx) (pr22 Hαα)) |] ;
+    + abstract
+        (unfold transportb ;
+         etrans ; [ apply (maponpaths (λ z, pr11 z x xx) (pr22 Hαα)) |] ;
          unfold transportb ;
          etrans ;
-         [ apply maponpaths ;
-           refine (maponpaths (λ z, pr1 z x xx) _) ;
+         [ refine (maponpaths (λ z, pr1 z x xx) _) ;
            exact (pr1_transportf
                     (!(vcomp_linv Hα))
                     (disp_nat_trans_id (pr11 GG),, tt))
          | ];
          etrans ;
-         [ apply maponpaths ;
-           exact (@disp_nat_trans_transportf
+         [ exact (@disp_nat_trans_transportf
                     _ _ _ _ _ _ _ _
                     (!(vcomp_linv Hα))
                     _ _
                     (disp_nat_trans_id (pr11 GG))
                     x xx)
          | ] ;
-         etrans ; [ apply transport_f_f | ] ;
          apply maponpaths_2 ;
-         apply homset_property).*)
-    + admit.
-      (* abstract
+         apply homset_property).
+    + abstract
         (unfold transportb ;
-         etrans ; [ apply mor_disp_transportf_prewhisker | ] ;
-         etrans ; [ apply maponpaths ; apply (maponpaths (λ z, pr11 z x xx) (pr12 Hαα)) |] ;
+         etrans ; [ apply (maponpaths (λ z, pr11 z x xx) (pr12 Hαα)) |] ;
          unfold transportb ;
          etrans ;
-         [ apply maponpaths ;
-           refine (maponpaths (λ z, pr1 z x xx) _) ;
+         [ refine (maponpaths (λ z, pr1 z x xx) _) ;
            exact (pr1_transportf
                     (!(vcomp_rinv Hα))
                     (disp_nat_trans_id (pr11 FF),, tt))
          | ] ;
          etrans ;
-         [ apply maponpaths ;
-           exact (@disp_nat_trans_transportf
+         [ exact (@disp_nat_trans_transportf
                     _ _ _ _ _ _ _ _
                     (!(vcomp_rinv Hα))
                     _ _
                     (disp_nat_trans_id (pr11 FF))
                     x xx)
          | ] ;
-         etrans ; [ apply transport_f_f | ] ;
          apply maponpaths_2 ;
          apply homset_property).
 Defined.
-       *)
-      Admitted.
 
 (** Displayed bicategory of opfibrations *)
 Definition disp_bicat_of_opcleaving_ob_mor
@@ -565,54 +549,44 @@ Proof.
   simple refine (_ ,, _).
   - exact (pr111 Hαα x xx).
   - split.
-    + admit. (*abstract
+    + abstract
         (unfold transportb ;
-         etrans ; [ apply mor_disp_transportf_postwhisker | ] ;
-         etrans ; [ apply maponpaths ; apply (maponpaths (λ z, pr11 z x xx) (pr22 Hαα)) |] ;
+         etrans ; [ apply (maponpaths (λ z, pr11 z x xx) (pr22 Hαα)) |] ;
          unfold transportb ;
          etrans ;
-         [ apply maponpaths ;
-           refine (maponpaths (λ z, pr1 z x xx) _) ;
+         [ refine (maponpaths (λ z, pr1 z x xx) _) ;
            exact (pr1_transportf
                     (!(vcomp_linv Hα))
                     (disp_nat_trans_id (pr11 GG),, tt))
          | ];
          etrans ;
-         [ apply maponpaths ;
-           exact (@disp_nat_trans_transportf
+         [ exact (@disp_nat_trans_transportf
                     _ _ _ _ _ _ _ _
                     (!(vcomp_linv Hα))
                     _ _
                     (disp_nat_trans_id (pr11 GG))
                     x xx)
          | ] ;
-         etrans ; [ apply transport_f_f | ] ;
          apply maponpaths_2 ;
-         apply homset_property). *)
-    + admit. (* abstract
+         apply homset_property).
+    + abstract
         (unfold transportb ;
-         etrans ; [ apply mor_disp_transportf_prewhisker | ] ;
-         etrans ; [ apply maponpaths ; apply (maponpaths (λ z, pr11 z x xx) (pr12 Hαα)) |] ;
+         etrans ; [ apply (maponpaths (λ z, pr11 z x xx) (pr12 Hαα)) |] ;
          unfold transportb ;
          etrans ;
-         [ apply maponpaths ;
-           refine (maponpaths (λ z, pr1 z x xx) _) ;
+         [ refine (maponpaths (λ z, pr1 z x xx) _) ;
            exact (pr1_transportf
                     (!(vcomp_rinv Hα))
                     (disp_nat_trans_id (pr11 FF),, tt))
          | ] ;
          etrans ;
-         [ apply maponpaths ;
-           exact (@disp_nat_trans_transportf
+         [ exact (@disp_nat_trans_transportf
                     _ _ _ _ _ _ _ _
                     (!(vcomp_rinv Hα))
                     _ _
                     (disp_nat_trans_id (pr11 FF))
                     x xx)
          | ] ;
-         etrans ; [ apply transport_f_f | ] ;
          apply maponpaths_2 ;
          apply homset_property).
 Defined.
-              *)
-      Admitted.

--- a/UniMath/Bicategories/DisplayedBicats/ExamplesOfCleavings/FibrationCleaving.v
+++ b/UniMath/Bicategories/DisplayedBicats/ExamplesOfCleavings/FibrationCleaving.v
@@ -376,14 +376,10 @@ Section Lift2CellCleaving.
       rewrite !mor_disp_transportf_prewhisker.
       rewrite !transport_f_f.
       do 3 apply maponpaths.
-      admit.
-      (*
       exact (disp_nat_trans_ax (pr11 (pr22 Lh')) ff).
     }
     unfold transportb.
     rewrite !mor_disp_transportf_prewhisker.
-    rewrite !transport_f_f.
-    rewrite !mor_disp_transportf_postwhisker.
     rewrite !transport_f_f.
     cbn.
     refine (!_).
@@ -399,8 +395,6 @@ Section Lift2CellCleaving.
     apply maponpaths_2.
     apply homset_property.
   Qed.
-       *)
-      Admitted.
 
   Definition cleaving_of_cleaving_lift_2cell
     : disp_nat_trans

--- a/UniMath/Bicategories/DisplayedBicats/ExamplesOfCleavings/OpFibrationCleaving.v
+++ b/UniMath/Bicategories/DisplayedBicats/ExamplesOfCleavings/OpFibrationCleaving.v
@@ -382,13 +382,10 @@ Section Lift2CellOpCleaving.
       rewrite !mor_disp_transportf_prewhisker.
       rewrite !transport_f_f.
       do 3 apply maponpaths.
-      admit. (*
       exact (disp_nat_trans_ax (pr11 (pr22 Lh')) ff).
     }
     unfold transportb.
     rewrite !mor_disp_transportf_prewhisker.
-    rewrite !transport_f_f.
-    rewrite !mor_disp_transportf_postwhisker.
     rewrite !transport_f_f.
     cbn.
     refine (!_).
@@ -404,8 +401,6 @@ Section Lift2CellOpCleaving.
     apply maponpaths_2.
     apply homset_property.
   Qed.
-              *)
-      Admitted.
 
   Definition cleaving_of_opcleaving_lift_2cell
     : disp_nat_trans

--- a/UniMath/Bicategories/PseudoFunctors/Preservation/BiadjunctionPreserveInserters.v
+++ b/UniMath/Bicategories/PseudoFunctors/Preservation/BiadjunctionPreserveInserters.v
@@ -151,10 +151,8 @@ Section BiadjunctionPreservation.
       etrans.
       {
         do 3 apply maponpaths.
-        admit.
-        (*
-        do 2 refine (vassocl _ _ _ @ _).
-        do 3 apply maponpaths.
+        refine (vassocl _ _ _ @ _).
+        do 2 apply maponpaths.
         do 6 refine (vassocl _ _ _ @ _).
         do 7 apply maponpaths.
         refine (vassocl _ _ _ @ _).
@@ -171,11 +169,6 @@ Section BiadjunctionPreservation.
         apply maponpaths_2.
         do 2 apply maponpaths.
         apply vassocl.
-      }
-      etrans.
-      {
-        do 5 apply maponpaths.
-        apply id2_left.
       }
       do 7 refine (_ @ vassocr _ _ _).
       refine (!_).
@@ -1110,8 +1103,7 @@ Section BiadjunctionPreservation.
       apply maponpaths.
       refine (!_).
       apply rwhisker_vcomp.
-    Qed. *)
-Admitted.
+    Qed.
 
     Transparent psfunctor_comp.
 


### PR DESCRIPTION
The admits are removed in the following files:
- `Bicategories/DisplayedBicats/Examples/DispBicatOfDispCats.v`
- `Bicategories/DisplayedBicats/ExamplesOfCleavings/FibrationCleaving.v`
- `Bicategories/DisplayedBicats/ExamplesOfCleavings/OpFibrationCleaving.v`
- `Bicategories/DisplayedBicats/Examples/CwF.v`
- `Bicategories/PseudoFunctors/Preservation/BiadjunctionPreserveInserters.v`