### PR TITLE
Continuity signature functor

### DIFF
--- a/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
+++ b/UniMath/SubstitutionSystems/ContinuitySignature/MultiSortedSignatureFunctorEquivalence.v
@@ -696,6 +696,7 @@ Section EquivalenceBetweenDifferentCharacterizationsOfMultiSortedSignatureToFunc
 
       transparent assert (q : (nat_z_iso (exp_functor_list sort Hsort C TC BP BC CC (cons x xs)) (BinProduct_of_functors BPC (exp_functor_list sort Hsort C TC BP BC CC xs) (exp_functor sort Hsort C TC BC CC x)))).
       {
+
         admit.
       }
 


### PR DESCRIPTION
Fixes the unfinished proof that omega_limits distribute over coproducts is independent of the choice of coproducts (in a univalent category).